### PR TITLE
feat(contracts): add Timelock governance module (#184)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "soromint-timelock"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+ "soromint-factory",
+]
+
+[[package]]
 name = "soromint-token"
 version = "0.1.0"
 dependencies = [

--- a/contracts/timelock/Cargo.toml
+++ b/contracts/timelock/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "soromint-timelock"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soromint-factory = { path = "../factory" }
+proptest = "1"

--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+mod timelock;
+
+pub use crate::timelock::{FactoryOperation, TimelockContract, TimelockContractClient};
+
+#[cfg(test)]
+mod test_timelock;

--- a/contracts/timelock/src/test_timelock.rs
+++ b/contracts/timelock/src/test_timelock.rs
@@ -1,0 +1,196 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+// Import the factory contract WASM for cross-contract testing.
+mod factory {
+    soroban_sdk::contractimport!(
+        file = "../../target/wasm32-unknown-unknown/release/soromint_factory.wasm"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, Address, TimelockContractClient<'static>) {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let timelock_id = e.register(TimelockContract, ());
+    let client = TimelockContractClient::new(&e, &timelock_id);
+    client.initialize(&admin);
+
+    (e, admin, client)
+}
+
+fn dummy_wasm_hash(e: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(e, &[seed; 32])
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize() {
+    let (e, admin, client) = setup();
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_delay(), 48 * 60 * 60);
+    let _ = e;
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_twice_panics() {
+    let (_, admin, client) = setup();
+    client.initialize(&admin);
+}
+
+// ---------------------------------------------------------------------------
+// Queue
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_queue_operation_returns_id() {
+    let (_, _, client) = setup();
+    let hash = dummy_wasm_hash(&soroban_sdk::Env::default(), 1);
+    let op = FactoryOperation::UpdateWasmHash(hash);
+    // Should not panic and should return a 32-byte id
+    let _op_id = client.queue_operation(&op);
+}
+
+#[test]
+#[should_panic(expected = "operation already queued")]
+fn test_queue_same_operation_twice_panics() {
+    let (e, _, client) = setup();
+    let hash = dummy_wasm_hash(&e, 2);
+    let op = FactoryOperation::UpdateWasmHash(hash);
+    client.queue_operation(&op);
+    // Ledger timestamp hasn't changed so eta is identical → same id
+    client.queue_operation(&op);
+}
+
+// ---------------------------------------------------------------------------
+// Cancel
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cancel_operation() {
+    let (e, _, client) = setup();
+    let hash = dummy_wasm_hash(&e, 3);
+    let op = FactoryOperation::UpdateWasmHash(hash.clone());
+
+    let eta = e.ledger().timestamp() + 48 * 60 * 60;
+    client.queue_operation(&op);
+
+    // Verify it is queued
+    assert!(client.get_operation_eta(&op, &eta).is_some());
+
+    client.cancel_operation(&op, &eta);
+
+    // Verify it is gone
+    assert!(client.get_operation_eta(&op, &eta).is_none());
+}
+
+#[test]
+#[should_panic(expected = "operation not found")]
+fn test_cancel_nonexistent_operation_panics() {
+    let (e, _, client) = setup();
+    let hash = dummy_wasm_hash(&e, 4);
+    let op = FactoryOperation::UpdateWasmHash(hash);
+    let eta = e.ledger().timestamp() + 48 * 60 * 60;
+    client.cancel_operation(&op, &eta);
+}
+
+// ---------------------------------------------------------------------------
+// Execute — delay enforcement
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "timelock delay not elapsed")]
+fn test_execute_before_delay_panics() {
+    let (e, _, client) = setup();
+    let hash = dummy_wasm_hash(&e, 5);
+    let op = FactoryOperation::UpdateWasmHash(hash.clone());
+
+    let eta = e.ledger().timestamp() + 48 * 60 * 60;
+    client.queue_operation(&op);
+
+    // Advance time by only 1 hour — still within the lock period
+    e.ledger().with_mut(|l| l.timestamp += 3600);
+
+    let dummy_factory = Address::generate(&e);
+    client.execute_operation(&dummy_factory, &op, &eta);
+}
+
+#[test]
+#[should_panic(expected = "operation not found")]
+fn test_execute_nonexistent_operation_panics() {
+    let (e, _, client) = setup();
+    let hash = dummy_wasm_hash(&e, 6);
+    let op = FactoryOperation::UpdateWasmHash(hash);
+    let eta = e.ledger().timestamp() + 48 * 60 * 60;
+
+    // Advance past the delay without queuing
+    e.ledger().with_mut(|l| l.timestamp += 48 * 60 * 60 + 1);
+
+    let dummy_factory = Address::generate(&e);
+    client.execute_operation(&dummy_factory, &op, &eta);
+}
+
+// ---------------------------------------------------------------------------
+// Full end-to-end with real factory WASM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_full_flow_update_wasm_hash() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    // Deploy timelock
+    let admin = Address::generate(&e);
+    let timelock_id = e.register(TimelockContract, ());
+    let timelock_client = TimelockContractClient::new(&e, &timelock_id);
+    timelock_client.initialize(&admin);
+
+    // Deploy factory with the timelock as its admin
+    let factory_id = e.register(factory::TokenFactory, ());
+    let factory_client = factory::Client::new(&e, &factory_id);
+
+    // Use a placeholder wasm hash for initialization (no real WASM needed here)
+    let initial_hash = BytesN::from_array(&e, &[0u8; 32]);
+    factory_client.initialize(&timelock_id, &initial_hash);
+
+    // Queue the update_wasm_hash operation through the timelock
+    let new_hash = BytesN::from_array(&e, &[9u8; 32]);
+    let op = FactoryOperation::UpdateWasmHash(new_hash.clone());
+    let eta = e.ledger().timestamp() + 48 * 60 * 60;
+
+    timelock_client.queue_operation(&op);
+
+    // Confirm it is recorded
+    assert!(timelock_client.get_operation_eta(&op, &eta).is_some());
+
+    // Advance ledger past the 48-hour delay
+    e.ledger().with_mut(|l| l.timestamp += 48 * 60 * 60 + 1);
+
+    // Execute — the timelock calls factory.update_wasm_hash on our behalf
+    timelock_client.execute_operation(&factory_id, &op, &eta);
+
+    // Operation should be cleared after execution
+    assert!(timelock_client.get_operation_eta(&op, &eta).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Views
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_version_and_status() {
+    let (e, _, client) = setup();
+    assert_eq!(client.version(), soroban_sdk::String::from_str(&e, "1.0.0"));
+    assert_eq!(client.status(), soroban_sdk::String::from_str(&e, "alive"));
+}

--- a/contracts/timelock/src/timelock.rs
+++ b/contracts/timelock/src/timelock.rs
@@ -1,0 +1,269 @@
+//! # SoroMint Timelock Contract
+//!
+//! A governance timelock that acts as the owner/admin of the Factory contract.
+//! Any administrative change (e.g. updating the WASM hash) must be queued and
+//! can only be executed after a mandatory 48-hour delay, giving the community
+//! time to review and react before the change takes effect.
+//!
+//! ## Flow
+//! 1. The Timelock admin calls `queue_operation` to schedule a factory call.
+//! 2. After 48 hours have elapsed on-chain, anyone may call `execute_operation`.
+//! 3. The admin may call `cancel_operation` at any time before execution.
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Symbol,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// 48 hours expressed in seconds.
+const DELAY: u64 = 48 * 60 * 60;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    /// The address that can queue and cancel operations.
+    Admin,
+    /// Stores the scheduled execution timestamp for a given operation id.
+    /// Value: u64 (ledger timestamp after which execution is allowed)
+    Op(BytesN<32>),
+}
+
+// ---------------------------------------------------------------------------
+// Operation types
+// ---------------------------------------------------------------------------
+
+/// The set of factory operations that can be queued through the timelock.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FactoryOperation {
+    /// Update the WASM hash used by the factory for future token deployments.
+    UpdateWasmHash(BytesN<32>),
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+const OP_QUEUED: Symbol = symbol_short!("op_queue");
+const OP_EXECUTED: Symbol = symbol_short!("op_exec");
+const OP_CANCELLED: Symbol = symbol_short!("op_cancel");
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Derives a deterministic 32-byte operation id from the operation payload and
+/// the eta (earliest execution timestamp).  Using both fields prevents replay
+/// of the same operation at a different time.
+fn operation_id(e: &Env, operation: &FactoryOperation, eta: u64) -> BytesN<32> {
+    // Encode the discriminant + eta into a fixed-size byte array so we can
+    // hash it with the SDK's built-in SHA-256.
+    let mut buf = [0u8; 40];
+
+    // Discriminant byte
+    let disc: u8 = match operation {
+        FactoryOperation::UpdateWasmHash(_) => 0,
+    };
+    buf[0] = disc;
+
+    // eta as big-endian u64 (8 bytes)
+    let eta_bytes = eta.to_be_bytes();
+    buf[1..9].copy_from_slice(&eta_bytes);
+
+    // For UpdateWasmHash, embed the 32-byte hash starting at offset 9
+    let hash_bytes = match operation {
+        FactoryOperation::UpdateWasmHash(hash) => hash.to_array(),
+    };
+    buf[9..41].copy_from_slice(&hash_bytes);
+
+    // SHA-256 over the 41 meaningful bytes
+    e.crypto().sha256(&soroban_sdk::Bytes::from_slice(e, &buf[..41])).into()
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct TimelockContract;
+
+#[contractimpl]
+impl TimelockContract {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Initialises the timelock with an admin address.
+    ///
+    /// # Arguments
+    /// * `admin` - The address that will be allowed to queue and cancel operations.
+    ///
+    /// # Panics
+    /// Panics if the contract has already been initialised.
+    pub fn initialize(e: Env, admin: Address) {
+        if e.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        e.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    // -----------------------------------------------------------------------
+    // Governance operations
+    // -----------------------------------------------------------------------
+
+    /// Queues a factory operation for execution after the 48-hour delay.
+    ///
+    /// # Arguments
+    /// * `operation` - The factory operation to schedule.
+    ///
+    /// # Returns
+    /// The 32-byte operation id that must be supplied to `execute_operation`
+    /// or `cancel_operation`.
+    ///
+    /// # Authorization
+    /// Requires the timelock admin to authorize.
+    ///
+    /// # Events
+    /// Emits `op_queue` with `(operation_id, eta)`.
+    pub fn queue_operation(e: Env, operation: FactoryOperation) -> BytesN<32> {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+
+        let now = e.ledger().timestamp();
+        let eta = now + DELAY;
+
+        let op_id = operation_id(&e, &operation, eta);
+
+        if e.storage().persistent().has(&DataKey::Op(op_id.clone())) {
+            panic!("operation already queued");
+        }
+
+        e.storage().persistent().set(&DataKey::Op(op_id.clone()), &eta);
+
+        e.events().publish(
+            (OP_QUEUED, admin),
+            (op_id.clone(), eta),
+        );
+
+        op_id
+    }
+
+    /// Executes a previously queued operation once the delay has elapsed.
+    ///
+    /// # Arguments
+    /// * `factory`   - The address of the Factory contract to call.
+    /// * `operation` - The factory operation to execute (must match the queued one).
+    /// * `eta`       - The eta that was returned when the operation was queued.
+    ///
+    /// # Authorization
+    /// No special authorization required — anyone may trigger execution once
+    /// the delay has passed.
+    ///
+    /// # Events
+    /// Emits `op_exec` with `(operation_id, factory)`.
+    pub fn execute_operation(e: Env, factory: Address, operation: FactoryOperation, eta: u64) {
+        let op_id = operation_id(&e, &operation, eta);
+
+        let stored_eta: u64 = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Op(op_id.clone()))
+            .expect("operation not found");
+
+        let now = e.ledger().timestamp();
+        if now < stored_eta {
+            panic!("timelock delay not elapsed");
+        }
+
+        // Remove before executing to prevent re-entrancy
+        e.storage().persistent().remove(&DataKey::Op(op_id.clone()));
+
+        // Dispatch the operation to the factory
+        match operation {
+            FactoryOperation::UpdateWasmHash(new_wasm_hash) => {
+                let args = soroban_sdk::vec![&e, new_wasm_hash.into()];
+                e.invoke_contract::<()>(
+                    &factory,
+                    &Symbol::new(&e, "update_wasm_hash"),
+                    args,
+                );
+            }
+        }
+
+        e.events().publish(
+            (OP_EXECUTED,),
+            (op_id, factory),
+        );
+    }
+
+    /// Cancels a queued operation before it is executed.
+    ///
+    /// # Arguments
+    /// * `operation` - The factory operation to cancel.
+    /// * `eta`       - The eta that was returned when the operation was queued.
+    ///
+    /// # Authorization
+    /// Requires the timelock admin to authorize.
+    ///
+    /// # Events
+    /// Emits `op_cancel` with `operation_id`.
+    pub fn cancel_operation(e: Env, operation: FactoryOperation, eta: u64) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+
+        let op_id = operation_id(&e, &operation, eta);
+
+        if !e.storage().persistent().has(&DataKey::Op(op_id.clone())) {
+            panic!("operation not found");
+        }
+
+        e.storage().persistent().remove(&DataKey::Op(op_id.clone()));
+
+        e.events().publish(
+            (OP_CANCELLED, admin),
+            op_id,
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Views
+    // -----------------------------------------------------------------------
+
+    /// Returns the scheduled eta for a queued operation, or `None` if it does
+    /// not exist.
+    ///
+    /// # Arguments
+    /// * `operation` - The factory operation to look up.
+    /// * `eta`       - The eta that was returned when the operation was queued.
+    pub fn get_operation_eta(e: Env, operation: FactoryOperation, eta: u64) -> Option<u64> {
+        let op_id = operation_id(&e, &operation, eta);
+        e.storage().persistent().get(&DataKey::Op(op_id))
+    }
+
+    /// Returns the current timelock admin address.
+    pub fn get_admin(e: Env) -> Address {
+        e.storage().instance().get(&DataKey::Admin).expect("not initialized")
+    }
+
+    /// Returns the minimum delay in seconds (48 hours).
+    pub fn get_delay(_e: Env) -> u64 {
+        DELAY
+    }
+
+    /// Returns the contract version string.
+    pub fn version(e: Env) -> String {
+        String::from_str(&e, "1.0.0")
+    }
+
+    /// Returns the operational status of the contract.
+    pub fn status(e: Env) -> String {
+        String::from_str(&e, "alive")
+    }
+}


### PR DESCRIPTION
Implements a Timelock contract that acts as the owner of the Factory, enforcing a mandatory 48-hour delay on all administrative changes so the community has time to review before execution.

## What's included

- contracts/timelock/Cargo.toml New workspace member wired up with soroban-sdk 22.0.0 and a dev-dependency on soromint-factory for integration tests.

- contracts/timelock/src/timelock.rs Core contract logic:
  - DELAY constant: 48 * 60 * 60 seconds
  - FactoryOperation enum (UpdateWasmHash)  extend as new factory admin functions are added
  - initialize(admin)          one-time setup, panics if repeated
  - queue_operation(op)        admin-only; schedules op, returns
                                deterministic SHA-256 op-id; emits op_queue
  - execute_operation(...)     permissionless after delay elapses;
                                removes op before dispatch (re-entrancy
                                safe); emits op_exec
  - cancel_operation(op, eta)  admin-only; removes queued op;
                                emits op_cancel
  - view helpers: get_operation_eta, get_admin, get_delay,
                  version, status

- contracts/timelock/src/lib.rs Crate root re-exporting TimelockContract, TimelockContractClient, and FactoryOperation.

- contracts/timelock/src/test_timelock.rs Unit and integration tests:
  - double-init panic
  - queue / cancel / execute happy paths
  - early-execution panic (delay not elapsed)
  - non-existent operation panics
  - full end-to-end flow using real factory WASM

## Usage

Deploy the Timelock, then initialise the Factory with the Timelock address as its admin:

  factory.initialize(timelock_address, wasm_hash)

From that point every update_wasm_hash call must go through:

  1. timelock.queue_operation(UpdateWasmHash(new_hash))
  2. wait >= 48 hours on-chain
  3. timelock.execute_operation(factory, UpdateWasmHash(new_hash), eta)
  
  closes #184