### PR TITLE
Dynamic update for meta-data, token resolver and hashes... DONE

### DIFF
--- a/contracts/factory/src/factory.rs
+++ b/contracts/factory/src/factory.rs
@@ -93,7 +93,7 @@ impl TokenFactory {
         address
     }
 
-    /// Deploys a new token contract (v2), initializes it, and sets a metadata hash.
+    /// Deploys a new token contract (v2), initializes it, and sets a metadata resolver.
     ///
     /// # Arguments
     /// * `salt`          - A unique 32-byte salt for the contract deployment.
@@ -101,7 +101,7 @@ impl TokenFactory {
     /// * `decimal`       - Number of decimal places for the new token.
     /// * `name`          - The name of the new token.
     /// * `symbol`        - The symbol of the new token.
-    /// * `metadata_hash` - An IPFS or content-addressed hash for off-chain metadata.
+    /// * `metadata_resolver` - Address of the resolver contract for off-chain metadata.
     ///
     /// # Returns
     /// The address of the newly deployed token contract.
@@ -115,7 +115,7 @@ impl TokenFactory {
         decimal: u32,
         name: String,
         symbol: String,
-        metadata_hash: String,
+        metadata_resolver: Address,
     ) -> Address {
         let wasm_hash: BytesN<32> = e.storage().instance().get(&DataKey::WasmHash).expect("not initialized");
 
@@ -135,15 +135,15 @@ impl TokenFactory {
             init_args,
         );
 
-        // Set the metadata hash on the newly deployed token contract
+        // Set the metadata resolver on the newly deployed token contract
         let meta_args = soroban_sdk::vec![
             &e,
-            metadata_hash.into_val(&e),
+            metadata_resolver.into_val(&e),
         ];
 
         e.invoke_contract::<()>(
             &address,
-            &Symbol::new(&e, "set_metadata_hash"),
+            &Symbol::new(&e, "set_metadata_resolver"),
             meta_args,
         );
 

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -8,7 +8,7 @@
 mod events;
 
 use soroban_sdk::token::TokenInterface;
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -21,6 +21,7 @@ pub enum DataKey {
     Decimals,
     Supply,
     MetadataHash,
+    MetadataResolver,
     FeeConfig,
 }
 
@@ -114,15 +115,31 @@ impl SoroMintToken {
         events::emit_ownership_transfer(&e, &admin, &new_admin);
     }
 
+    /// Legacy method to set metadata hash directly. Preserved for v1 compatibility.
     pub fn set_metadata_hash(e: Env, hash: String) {
         let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         e.storage().instance().set(&DataKey::MetadataHash, &hash);
-        // Using a simpler version of metadata update event for hash
-        // events::emit_metadata_updated(&e, &admin, &hash); // This was in old code, but let's stick to update_metadata
     }
 
+    /// Sets a resolver contract address that will provide the metadata hash.
+    /// This decouples metadata storage from the core token contract.
+    pub fn set_metadata_resolver(e: Env, resolver: Address) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::MetadataResolver, &resolver);
+    }
+
+    /// Retrieves the metadata hash. Priorities the resolver if set, 
+    /// otherwise falls back to the locally stored hash.
     pub fn metadata_hash(e: Env) -> Option<String> {
+        if let Some(resolver) = e.storage().instance().get::<Address>(&DataKey::MetadataResolver) {
+            return e.invoke_contract::<Option<String>>(
+                &resolver,
+                &Symbol::new(&e, "get_metadata_hash"),
+                soroban_sdk::vec![&e],
+            );
+        }
         e.storage().instance().get(&DataKey::MetadataHash)
     }
 

--- a/docs/contract-api.md
+++ b/docs/contract-api.md
@@ -24,16 +24,15 @@ Returns the current health or operational status of the contract.
 
 The token supports a link to external rich metadata stored on decentralized storage platforms.
 
-### `set_metadata_hash()`
-Sets the IPFS or Arweave hash for external metadata. Requires admin authorization.
+### `set_metadata_resolver()`
+Sets the address of the resolver contract that provides the external metadata hash. Requires admin authorization.
 
-- **Signature**: `set_metadata_hash(e: Env, hash: String)`
+- **Signature**: `set_metadata_resolver(e: Env, resolver: Address)`
 - **Returns**: `()` (void)
 - **Events**: Emits a `metadata_updated` event.
 
 ### `metadata_hash()`
-Returns the current metadata hash if set.
+Returns the current metadata hash by querying the configured resolver (or local storage as fallback).
 
 - **Signature**: `metadata_hash(e: Env) -> Option<String>`
 - **Returns**: `Option<String>` containing the hash or `None`.
-

--- a/docs/external-metadata.md
+++ b/docs/external-metadata.md
@@ -10,14 +10,14 @@ Tokens often need more metadata than can be efficiently stored directly on the b
 
 ### Functions
 
-#### `set_metadata_hash(e: Env, hash: String)`
-Sets the metadata hash for the token.
+#### `set_metadata_resolver(e: Env, resolver: Address)`
+Sets the resolver address for the token.
 - **Authorization**: Only the contract administrator (admin) can call this function.
-- **Args**: `hash` is a `String` representing the IPFS/Arweave hash.
+- **Args**: `resolver` is an `Address` of a contract implementing `get_metadata_hash() -> Option<String>`.
 - **Events**: Emits a `metadata_updated` event.
 
 #### `metadata_hash(e: Env) -> Option<String>`
-Retrieves the current metadata hash.
+Retrieves the current metadata hash by querying the configured resolver.
 - **Returns**: `Some(hash)` if a hash has been set, otherwise `None`.
 
 ### Security Considerations
@@ -28,10 +28,11 @@ Retrieves the current metadata hash.
 
 ## Example Usage
 
-### Setting a Metadata Hash (IPFS)
-To link to a metadata file on IPFS with CID `QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco`:
+### Setting a Metadata Resolver
+To decouple metadata, point the token to a resolver contract:
 ```rust
-token.set_metadata_hash("QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco");
+let resolver_address = ...; // Address of your MetadataResolver contract
+token.set_metadata_resolver(resolver_address);
 ```
 
 ### Retrieving the Hash


### PR DESCRIPTION
# Close #185 

Token Contract ([contracts/token/src/lib.rs](code-assist-path:/workspaces/SoroMint/contracts/token/src/lib.rs)):

A new DataKey::MetadataResolver was added to store the address of a resolver contract.
A new public function, set_metadata_resolver, allows the admin to set this resolver address.
The metadata_hash function was updated to first check if a MetadataResolver is set. If so, it invokes the get_metadata_hash method on that resolver contract to retrieve the metadata hash. If no resolver is configured, it falls back to the locally stored MetadataHash (for backward compatibility).
The existing set_metadata_hash function is now explicitly marked as a "Legacy method" for v1 compatibility.
Factory Contract ([contracts/factory/src/factory.rs](code-assist-path:/workspaces/SoroMint/contracts/factory/src/factory.rs)):

The v2_create_token entry point was modified. Instead of accepting a metadata_hash: String, it now takes a metadata_resolver: Address.
After deploying and initializing the new token, v2_create_token now calls the token's new set_metadata_resolver function to link it to the provided resolver address.
Documentation ([docs/contract-api.md](code-assist-path:/workspaces/SoroMint/docs/contract-api.md), [docs/external-metadata.md](code-assist-path:/workspaces/SoroMint/docs/external-metadata.md)):

The API documentation was updated to reflect the new set_metadata_resolver function and the updated behavior of metadata_hash.
The concept of using a resolver contract for external metadata is now clearly outlined.
In essence, these changes enable tokens to dynamically update their metadata by simply changing the resolver contract or updating the state within the resolver, without requiring a redeployment or upgrade of the token contract itself.