### PR TITLE
fix: Developer API Gateway with Usage Tracking

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,4 @@
-require("dotenv").config();
+require('dotenv').config();
 
 /**
  * @title SoroMint Server Entry Point
@@ -6,40 +6,47 @@ require("dotenv").config();
  * @notice Initializes the backend and registers all route modules
  */
 
-const { initEnv, getEnv } = require("./config/env-config");
+const { initEnv, getEnv } = require('./config/env-config');
 initEnv();
 
-const { scheduleBackups } = require("./services/backup-service");
-const { getCacheService } = require("./services/cache-service");
+const { scheduleBackups } = require('./services/backup-service');
+const { getCacheService } = require('./services/cache-service');
 
-const express = require("express");
-const mongoose = require("mongoose");
-const cors = require("cors");
-const { securityHeaders } = require("./middleware/security-headers");
-const { createCorsOptionsDelegate } = require("./config/cors-config");
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const { securityHeaders } = require('./middleware/security-headers');
+const { createCorsOptionsDelegate } = require('./config/cors-config');
 
-const { initSentry } = require("./config/sentry");
-const { errorHandler, notFoundHandler } = require("./middleware/error-handler");
+const { initSentry } = require('./config/sentry');
+const { errorHandler, notFoundHandler } = require('./middleware/error-handler');
 const {
   logger,
   correlationIdMiddleware,
   httpLoggerMiddleware,
   logStartupInfo,
   logDatabaseConnection,
-} = require("./utils/logger");
-const { setupSwagger } = require("./config/swagger");
-const { sampler } = require("./services/resource-sampler");
-const authRoutes = require("./routes/auth-routes");
-const statusRoutes = require("./routes/status-routes");
-const auditRoutes = require("./routes/audit-routes");
-const tokenRoutes = require("./routes/token-routes");
-const webhookRoutes = require("./routes/webhook-routes");
-const analyticsRoutes = require("./routes/analytics-routes");
-const notificationRoutes = require("./routes/notification-routes");
-const multiSigRoutes = require("./routes/multisig-routes");
-const vaultRoutes = require("./routes/vault-routes");
+} = require('./utils/logger');
+const { setupSwagger } = require('./config/swagger');
+const { sampler } = require('./services/resource-sampler');
+const authRoutes = require('./routes/auth-routes');
+const statusRoutes = require('./routes/status-routes');
+const auditRoutes = require('./routes/audit-routes');
+const tokenRoutes = require('./routes/token-routes');
+const webhookRoutes = require('./routes/webhook-routes');
+const analyticsRoutes = require('./routes/analytics-routes');
+const notificationRoutes = require('./routes/notification-routes');
+const multiSigRoutes = require('./routes/multisig-routes');
+const vaultRoutes = require('./routes/vault-routes');
+const apiKeyRoutes = require('./routes/api-key-routes');
+const developerGatewayRoutes = require('./routes/developer-gateway-routes');
 
-const createApp = ({ authRouter = authRoutes, tokenRouter = tokenRoutes } = {}) => {
+const createApp = ({
+  authRouter = authRoutes,
+  tokenRouter = tokenRoutes,
+  apiKeyRouter = apiKeyRoutes,
+  developerGatewayRouter = developerGatewayRoutes,
+} = {}) => {
   const app = express();
   const corsMiddleware = cors(createCorsOptionsDelegate());
 
@@ -48,20 +55,22 @@ const createApp = ({ authRouter = authRoutes, tokenRouter = tokenRoutes } = {}) 
   app.use(correlationIdMiddleware);
   app.use(httpLoggerMiddleware);
   app.use(corsMiddleware);
-  app.options("*", corsMiddleware);
+  app.options('*', corsMiddleware);
   app.use(express.json());
 
   setupSwagger(app);
 
-  app.use("/api", statusRoutes);
-  app.use("/api", auditRoutes);
-  app.use("/api", tokenRouter);
-  app.use("/api", analyticsRoutes);
-  app.use("/api", notificationRoutes);
-  app.use("/api/auth", authRouter);
-  app.use("/api", webhookRoutes);
-  app.use("/api/multisig", multiSigRoutes);
-  app.use("/api/vault", vaultRoutes);
+  app.use('/api', statusRoutes);
+  app.use('/api', auditRoutes);
+  app.use('/api', tokenRouter);
+  app.use('/api', analyticsRoutes);
+  app.use('/api', notificationRoutes);
+  app.use('/api/auth', authRouter);
+  app.use('/api', webhookRoutes);
+  app.use('/api/multisig', multiSigRoutes);
+  app.use('/api/vault', vaultRoutes);
+  app.use('/api/api-keys', apiKeyRouter);
+  app.use('/api/v1/developer', developerGatewayRouter);
 
   app.use(notFoundHandler);
   app.use(errorHandler);
@@ -88,11 +97,14 @@ const startServer = async () => {
   const cacheService = getCacheService();
   try {
     await cacheService.initialize();
-    logger.info("Cache service initialized successfully");
+    logger.info('Cache service initialized successfully');
   } catch (error) {
-    logger.warn("Cache service initialization failed, continuing without cache", {
-      error: error.message,
-    });
+    logger.warn(
+      'Cache service initialization failed, continuing without cache',
+      {
+        error: error.message,
+      }
+    );
   }
 
   await connectDatabase();
@@ -102,14 +114,16 @@ const startServer = async () => {
     logStartupInfo(env.PORT, env.NETWORK_PASSPHRASE);
     sampler.start();
     console.log(`Server running on http://localhost:${env.PORT}`);
-    console.log(`API Documentation available at http://localhost:${env.PORT}/api-docs`);
+    console.log(
+      `API Documentation available at http://localhost:${env.PORT}/api-docs`
+    );
     scheduleBackups();
   });
 };
 
 if (require.main === module) {
   startServer().catch((error) => {
-    logger.error("Server failed to start", { error: error.message });
+    logger.error('Server failed to start', { error: error.message });
     setImmediate(() => {
       throw error;
     });

--- a/server/middleware/api-key-auth.js
+++ b/server/middleware/api-key-auth.js
@@ -1,0 +1,210 @@
+const ApiKey = require('../models/ApiKey');
+const ApiUsage = require('../models/ApiUsage');
+const { AppError } = require('./error-handler');
+const { logger } = require('../utils/logger');
+
+/**
+ * @title API Key Authentication & Rate Limiting Middleware
+ * @author SoroMint Team
+ * @notice Authenticates developer-gateway requests via API key, enforces a
+ *         per-key sliding-window rate limit, and records usage for billing
+ *         and analytics.
+ */
+
+const API_KEY_HEADER = 'x-api-key';
+const AUTHORIZATION_HEADER = 'authorization';
+
+/**
+ * @notice In-memory sliding-window counters keyed by API key id
+ * @dev Exposed for tests to reset. Each entry is { windowStart, count, max,
+ *      windowMs }. Using an in-process store is sufficient for a single
+ *      instance; for multi-node deployments swap this out for Redis.
+ */
+const rateLimitBuckets = new Map();
+
+/**
+ * @notice Clears the in-memory rate limit buckets
+ * @dev Intended for use in tests
+ */
+const resetRateLimitBuckets = () => {
+  rateLimitBuckets.clear();
+};
+
+/**
+ * @notice Extracts the presented API key from the request
+ * @param {Object} req - Express request
+ * @returns {string|null}
+ */
+const extractApiKey = (req) => {
+  const headerKey = req.headers[API_KEY_HEADER];
+  if (typeof headerKey === 'string' && headerKey.trim()) {
+    return headerKey.trim();
+  }
+
+  const authHeader = req.headers[AUTHORIZATION_HEADER];
+  if (typeof authHeader === 'string' && authHeader.startsWith('ApiKey ')) {
+    return authHeader.substring(7).trim();
+  }
+
+  return null;
+};
+
+/**
+ * @notice Applies a sliding-window rate limit for an API key
+ * @param {Object} apiKey - ApiKey document
+ * @returns {{ allowed: boolean, remaining: number, resetAt: number, limit: number, windowMs: number }}
+ */
+const consumeRateLimit = (apiKey) => {
+  const { windowMs, max } = apiKey.getRateLimit();
+  const now = Date.now();
+  const bucketKey = apiKey._id.toString();
+
+  let bucket = rateLimitBuckets.get(bucketKey);
+  if (!bucket || now - bucket.windowStart >= windowMs) {
+    bucket = { windowStart: now, count: 0, max, windowMs };
+    rateLimitBuckets.set(bucketKey, bucket);
+  } else {
+    // Pick up any limit changes from key rotation/tier change
+    bucket.max = max;
+    bucket.windowMs = windowMs;
+  }
+
+  bucket.count += 1;
+  const remaining = Math.max(0, bucket.max - bucket.count);
+  const resetAt = bucket.windowStart + bucket.windowMs;
+  const allowed = bucket.count <= bucket.max;
+
+  return { allowed, remaining, resetAt, limit: bucket.max, windowMs };
+};
+
+/**
+ * @notice Writes a usage record once the response has finished
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ * @param {Object} apiKey - ApiKey document
+ * @param {number} startTime - High-resolution start timestamp (ms)
+ */
+const recordUsage = (req, res, apiKey, startTime) => {
+  res.on('finish', () => {
+    const durationMs = Date.now() - startTime;
+    const doc = {
+      apiKeyId: apiKey._id,
+      ownerPublicKey: apiKey.ownerPublicKey,
+      method: req.method,
+      path: req.originalUrl || req.url,
+      statusCode: res.statusCode,
+      durationMs,
+      ip: req.ip || req.connection?.remoteAddress,
+      userAgent: req.get ? req.get('user-agent') : undefined,
+      timestamp: new Date(),
+    };
+
+    ApiUsage.create(doc).catch((error) => {
+      logger.warn('Failed to record API usage', {
+        error: error.message,
+        apiKeyId: apiKey._id.toString(),
+      });
+    });
+  });
+};
+
+/**
+ * @notice Express middleware that authenticates an API key, enforces its
+ *         rate limit, and attaches it to req.apiKey.
+ * @param {Object} [options]
+ * @param {string[]} [options.requiredScopes] - Scopes the caller must have
+ * @returns {Function} Express middleware
+ */
+const apiKeyAuth = ({ requiredScopes = [] } = {}) => {
+  return async (req, res, next) => {
+    try {
+      const plaintext = extractApiKey(req);
+      if (!plaintext) {
+        throw new AppError(
+          'API key required. Provide it via the X-API-Key header.',
+          401,
+          'API_KEY_REQUIRED'
+        );
+      }
+
+      const apiKey = await ApiKey.findByPlaintext(plaintext);
+      if (!apiKey) {
+        throw new AppError('Invalid API key.', 401, 'INVALID_API_KEY');
+      }
+
+      if (!apiKey.isUsable()) {
+        const code =
+          apiKey.status === 'revoked' ? 'API_KEY_REVOKED' : 'API_KEY_EXPIRED';
+        throw new AppError(
+          `API key is ${apiKey.status === 'revoked' ? 'revoked' : 'expired'}.`,
+          401,
+          code
+        );
+      }
+
+      if (requiredScopes.length > 0) {
+        const missing = requiredScopes.filter(
+          (scope) => !apiKey.scopes.includes(scope)
+        );
+        if (missing.length > 0) {
+          throw new AppError(
+            `API key is missing required scope(s): ${missing.join(', ')}`,
+            403,
+            'INSUFFICIENT_SCOPE'
+          );
+        }
+      }
+
+      const { allowed, remaining, resetAt, limit, windowMs } =
+        consumeRateLimit(apiKey);
+
+      res.setHeader('X-RateLimit-Limit', String(limit));
+      res.setHeader('X-RateLimit-Remaining', String(remaining));
+      res.setHeader('X-RateLimit-Reset', String(Math.ceil(resetAt / 1000)));
+      res.setHeader('X-RateLimit-Window', String(windowMs));
+
+      if (!allowed) {
+        const retryAfterSeconds = Math.max(
+          1,
+          Math.ceil((resetAt - Date.now()) / 1000)
+        );
+        res.setHeader('Retry-After', String(retryAfterSeconds));
+        throw new AppError(
+          'Too many requests. Please try again later.',
+          429,
+          'RATE_LIMIT_EXCEEDED'
+        );
+      }
+
+      req.apiKey = apiKey;
+      req.apiKeyOwnerPublicKey = apiKey.ownerPublicKey;
+
+      recordUsage(req, res, apiKey, Date.now());
+
+      // Best-effort counter + last-used timestamp; failures should not block
+      // the request.
+      ApiKey.updateOne(
+        { _id: apiKey._id },
+        { $set: { lastUsedAt: new Date() }, $inc: { usageCount: 1 } }
+      ).catch((error) => {
+        logger.warn('Failed to update API key usage counters', {
+          error: error.message,
+          apiKeyId: apiKey._id.toString(),
+        });
+      });
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+};
+
+module.exports = {
+  apiKeyAuth,
+  extractApiKey,
+  consumeRateLimit,
+  resetRateLimitBuckets,
+  rateLimitBuckets,
+  API_KEY_HEADER,
+};

--- a/server/models/ApiKey.js
+++ b/server/models/ApiKey.js
@@ -1,0 +1,221 @@
+const mongoose = require('mongoose');
+const crypto = require('crypto');
+
+/**
+ * @title ApiKey Model
+ * @author SoroMint Team
+ * @notice Stores developer API keys used by the Developer API Gateway
+ * @dev Only a SHA-256 hash of the full key is persisted. The plaintext key is
+ *      returned exactly once at creation time. A short non-secret `prefix` is
+ *      retained so users can identify keys in UI/logs without ever exposing
+ *      the secret portion.
+ */
+
+const VALID_SCOPES = ['tokens:read', 'tokens:write', 'analytics:read'];
+const VALID_TIERS = ['free', 'pro', 'enterprise'];
+const VALID_STATUSES = ['active', 'revoked'];
+
+const TIER_DEFAULT_RATE_LIMITS = {
+  free: { windowMs: 60 * 1000, max: 60 },
+  pro: { windowMs: 60 * 1000, max: 600 },
+  enterprise: { windowMs: 60 * 1000, max: 6000 },
+};
+
+const ApiKeySchema = new mongoose.Schema(
+  {
+    /**
+     * Owning user's Stellar public key
+     */
+    ownerPublicKey: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    /**
+     * Human-readable label for the key (e.g. "prod-backend")
+     */
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 1,
+      maxlength: 100,
+    },
+    /**
+     * Non-secret identifier shown to the user (first 8 chars of plaintext
+     * key, prefixed with "sm_"). Safe to display in listings.
+     */
+    prefix: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    /**
+     * SHA-256 hash of the plaintext API key. Used for verification.
+     */
+    keyHash: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    /**
+     * Pricing/usage tier which drives the default rate limit.
+     */
+    tier: {
+      type: String,
+      enum: VALID_TIERS,
+      default: 'free',
+    },
+    /**
+     * Authorized scopes that restrict what endpoints the key can call.
+     */
+    scopes: {
+      type: [String],
+      default: ['tokens:read'],
+      validate: {
+        validator: (scopes) => scopes.every((s) => VALID_SCOPES.includes(s)),
+        message: 'Invalid scope. Allowed: ' + VALID_SCOPES.join(', '),
+      },
+    },
+    /**
+     * Per-key rate-limit overrides. When absent, tier defaults are used.
+     */
+    rateLimit: {
+      windowMs: { type: Number, min: 1000 },
+      max: { type: Number, min: 1 },
+    },
+    /**
+     * Lifecycle status of the key.
+     */
+    status: {
+      type: String,
+      enum: VALID_STATUSES,
+      default: 'active',
+      index: true,
+    },
+    /**
+     * Optional expiration timestamp. Null/undefined means never expires.
+     */
+    expiresAt: {
+      type: Date,
+      default: null,
+    },
+    /**
+     * Last time the key was used to authenticate a request.
+     */
+    lastUsedAt: {
+      type: Date,
+      default: null,
+    },
+    /**
+     * Monotonic counter of successful authentications.
+     */
+    usageCount: {
+      type: Number,
+      default: 0,
+    },
+  },
+  { timestamps: true }
+);
+
+ApiKeySchema.index({ ownerPublicKey: 1, status: 1 });
+
+/**
+ * @notice Computes the SHA-256 hash of a plaintext key
+ * @param {string} plaintext - Full API key
+ * @returns {string} Hex-encoded hash
+ */
+ApiKeySchema.statics.hashKey = function (plaintext) {
+  return crypto.createHash('sha256').update(plaintext).digest('hex');
+};
+
+/**
+ * @notice Generates a fresh random API key (plaintext)
+ * @dev Key format: "sm_<base64url-40-bytes>". The "sm_" prefix allows GitHub
+ *      secret scanning integrations and log scrubbers to identify the token.
+ * @returns {string} Plaintext API key
+ */
+ApiKeySchema.statics.generatePlaintext = function () {
+  const random = crypto.randomBytes(30).toString('base64url');
+  return `sm_${random}`;
+};
+
+/**
+ * @notice Derives the public prefix shown to the user from a plaintext key
+ * @param {string} plaintext - Full API key
+ * @returns {string} First 11 characters (prefix + first 8 of secret)
+ */
+ApiKeySchema.statics.derivePrefix = function (plaintext) {
+  return plaintext.slice(0, 11);
+};
+
+/**
+ * @notice Locates an active key by its plaintext value
+ * @param {string} plaintext - Full API key submitted by a client
+ * @returns {Promise<ApiKey|null>}
+ */
+ApiKeySchema.statics.findByPlaintext = async function (plaintext) {
+  if (!plaintext || typeof plaintext !== 'string') {
+    return null;
+  }
+  const keyHash = this.hashKey(plaintext);
+  return this.findOne({ keyHash });
+};
+
+/**
+ * @notice Returns the effective rate limit for the key
+ * @returns {{ windowMs: number, max: number }}
+ */
+ApiKeySchema.methods.getRateLimit = function () {
+  const tierDefaults =
+    TIER_DEFAULT_RATE_LIMITS[this.tier] || TIER_DEFAULT_RATE_LIMITS.free;
+  const override = this.rateLimit || {};
+  return {
+    windowMs: override.windowMs || tierDefaults.windowMs,
+    max: override.max || tierDefaults.max,
+  };
+};
+
+/**
+ * @notice Indicates whether the key is usable right now
+ * @returns {boolean}
+ */
+ApiKeySchema.methods.isUsable = function () {
+  if (this.status !== 'active') {
+    return false;
+  }
+  if (this.expiresAt && this.expiresAt.getTime() <= Date.now()) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * @notice Returns a client-safe representation of the key (no secrets)
+ * @returns {Object}
+ */
+ApiKeySchema.methods.toSafeJSON = function () {
+  return {
+    id: this._id,
+    name: this.name,
+    prefix: this.prefix,
+    tier: this.tier,
+    scopes: this.scopes,
+    rateLimit: this.getRateLimit(),
+    status: this.status,
+    expiresAt: this.expiresAt,
+    lastUsedAt: this.lastUsedAt,
+    usageCount: this.usageCount,
+    createdAt: this.createdAt,
+    updatedAt: this.updatedAt,
+  };
+};
+
+const ApiKey = mongoose.model('ApiKey', ApiKeySchema);
+
+module.exports = ApiKey;
+module.exports.VALID_SCOPES = VALID_SCOPES;
+module.exports.VALID_TIERS = VALID_TIERS;
+module.exports.VALID_STATUSES = VALID_STATUSES;
+module.exports.TIER_DEFAULT_RATE_LIMITS = TIER_DEFAULT_RATE_LIMITS;

--- a/server/models/ApiUsage.js
+++ b/server/models/ApiUsage.js
@@ -1,0 +1,50 @@
+const mongoose = require('mongoose');
+
+/**
+ * @title ApiUsage Model
+ * @author SoroMint Team
+ * @notice Per-request usage log for the Developer API Gateway
+ * @dev Used to compute usage statistics and quotas. A TTL index keeps the
+ *      collection from growing unbounded (default 90 days).
+ */
+
+const USAGE_RETENTION_DAYS = 90;
+
+const ApiUsageSchema = new mongoose.Schema(
+  {
+    apiKeyId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'ApiKey',
+      required: true,
+      index: true,
+    },
+    ownerPublicKey: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    method: { type: String, required: true },
+    path: { type: String, required: true },
+    statusCode: { type: Number, required: true },
+    durationMs: { type: Number, default: 0 },
+    ip: { type: String },
+    userAgent: { type: String },
+    timestamp: {
+      type: Date,
+      default: Date.now,
+      index: true,
+    },
+  },
+  { versionKey: false }
+);
+
+ApiUsageSchema.index(
+  { timestamp: 1 },
+  { expireAfterSeconds: USAGE_RETENTION_DAYS * 24 * 60 * 60 }
+);
+ApiUsageSchema.index({ apiKeyId: 1, timestamp: -1 });
+
+const ApiUsage = mongoose.model('ApiUsage', ApiUsageSchema);
+
+module.exports = ApiUsage;
+module.exports.USAGE_RETENTION_DAYS = USAGE_RETENTION_DAYS;

--- a/server/routes/api-key-routes.js
+++ b/server/routes/api-key-routes.js
@@ -1,0 +1,326 @@
+const express = require('express');
+const { z } = require('zod');
+const ApiKey = require('../models/ApiKey');
+const ApiUsage = require('../models/ApiUsage');
+const { authenticate } = require('../middleware/auth');
+const { asyncHandler, AppError } = require('../middleware/error-handler');
+const { logger } = require('../utils/logger');
+
+/**
+ * @title API Key Management Routes
+ * @author SoroMint Team
+ * @notice JWT-authenticated endpoints allowing users to create, list, rotate,
+ *         update, revoke, and inspect usage of their developer API keys.
+ *         The Developer API Gateway itself is defined in
+ *         developer-gateway-routes.js and authenticates via the API key.
+ */
+
+const createSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'name is required')
+    .max(100, 'name must be at most 100 characters'),
+  tier: z.enum(ApiKey.VALID_TIERS).optional(),
+  scopes: z.array(z.enum(ApiKey.VALID_SCOPES)).nonempty().optional(),
+  rateLimit: z
+    .object({
+      windowMs: z.number().int().min(1000),
+      max: z.number().int().min(1),
+    })
+    .optional(),
+  expiresAt: z
+    .union([z.string().datetime(), z.null()])
+    .optional()
+    .transform((value) => (value ? new Date(value) : null)),
+});
+
+const updateSchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  tier: z.enum(ApiKey.VALID_TIERS).optional(),
+  scopes: z.array(z.enum(ApiKey.VALID_SCOPES)).nonempty().optional(),
+  rateLimit: z
+    .object({
+      windowMs: z.number().int().min(1000),
+      max: z.number().int().min(1),
+    })
+    .nullable()
+    .optional(),
+  expiresAt: z
+    .union([z.string().datetime(), z.null()])
+    .optional()
+    .transform((value) =>
+      value === undefined ? undefined : value ? new Date(value) : null
+    ),
+});
+
+const parseOrThrow = (schema, payload) => {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join(', ');
+    throw new AppError(message, 400, 'VALIDATION_ERROR');
+  }
+  return parsed.data;
+};
+
+const findOwnedKey = async (id, ownerPublicKey) => {
+  const apiKey = await ApiKey.findOne({ _id: id, ownerPublicKey });
+  if (!apiKey) {
+    throw new AppError('API key not found', 404, 'NOT_FOUND');
+  }
+  return apiKey;
+};
+
+const createApiKeyRouter = () => {
+  const router = express.Router();
+
+  /**
+   * @route POST /api/api-keys
+   * @desc  Issue a new API key for the authenticated user. The plaintext
+   *        value is returned exactly once in this response.
+   */
+  router.post(
+    '/',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const data = parseOrThrow(createSchema, req.body);
+
+      const plaintext = ApiKey.generatePlaintext();
+      const keyHash = ApiKey.hashKey(plaintext);
+      const prefix = ApiKey.derivePrefix(plaintext);
+
+      const apiKey = await ApiKey.create({
+        ownerPublicKey: req.user.publicKey,
+        name: data.name,
+        tier: data.tier || 'free',
+        scopes: data.scopes || ['tokens:read'],
+        rateLimit: data.rateLimit || undefined,
+        expiresAt: data.expiresAt || null,
+        prefix,
+        keyHash,
+      });
+
+      logger.info('Issued developer API key', {
+        correlationId: req.correlationId,
+        apiKeyId: apiKey._id.toString(),
+        ownerPublicKey: req.user.publicKey,
+      });
+
+      res.status(201).json({
+        success: true,
+        data: {
+          ...apiKey.toSafeJSON(),
+          key: plaintext,
+          warning:
+            'Store this key securely. It cannot be retrieved again after this response.',
+        },
+      });
+    })
+  );
+
+  /**
+   * @route GET /api/api-keys
+   * @desc  List the authenticated user's API keys (no plaintext).
+   */
+  router.get(
+    '/',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const keys = await ApiKey.find({
+        ownerPublicKey: req.user.publicKey,
+      }).sort({ createdAt: -1 });
+
+      res.json({
+        success: true,
+        data: keys.map((key) => key.toSafeJSON()),
+      });
+    })
+  );
+
+  /**
+   * @route GET /api/api-keys/:id
+   * @desc  Fetch a single API key by id.
+   */
+  router.get(
+    '/:id',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const apiKey = await findOwnedKey(req.params.id, req.user.publicKey);
+      res.json({ success: true, data: apiKey.toSafeJSON() });
+    })
+  );
+
+  /**
+   * @route PATCH /api/api-keys/:id
+   * @desc  Update mutable fields (name, tier, scopes, rateLimit, expiresAt).
+   */
+  router.patch(
+    '/:id',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const data = parseOrThrow(updateSchema, req.body);
+      const apiKey = await findOwnedKey(req.params.id, req.user.publicKey);
+
+      if (data.name !== undefined) apiKey.name = data.name;
+      if (data.tier !== undefined) apiKey.tier = data.tier;
+      if (data.scopes !== undefined) apiKey.scopes = data.scopes;
+      if (data.rateLimit !== undefined) {
+        apiKey.rateLimit = data.rateLimit || undefined;
+      }
+      if (data.expiresAt !== undefined) apiKey.expiresAt = data.expiresAt;
+
+      await apiKey.save();
+
+      res.json({ success: true, data: apiKey.toSafeJSON() });
+    })
+  );
+
+  /**
+   * @route POST /api/api-keys/:id/rotate
+   * @desc  Invalidate the current secret and issue a new plaintext value.
+   */
+  router.post(
+    '/:id/rotate',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const apiKey = await findOwnedKey(req.params.id, req.user.publicKey);
+
+      const plaintext = ApiKey.generatePlaintext();
+      apiKey.keyHash = ApiKey.hashKey(plaintext);
+      apiKey.prefix = ApiKey.derivePrefix(plaintext);
+      apiKey.status = 'active';
+      await apiKey.save();
+
+      logger.info('Rotated developer API key', {
+        correlationId: req.correlationId,
+        apiKeyId: apiKey._id.toString(),
+        ownerPublicKey: req.user.publicKey,
+      });
+
+      res.json({
+        success: true,
+        data: {
+          ...apiKey.toSafeJSON(),
+          key: plaintext,
+          warning:
+            'Store this key securely. It cannot be retrieved again after this response.',
+        },
+      });
+    })
+  );
+
+  /**
+   * @route POST /api/api-keys/:id/revoke
+   * @desc  Permanently disable the API key.
+   */
+  router.post(
+    '/:id/revoke',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const apiKey = await findOwnedKey(req.params.id, req.user.publicKey);
+      apiKey.status = 'revoked';
+      await apiKey.save();
+
+      res.json({ success: true, data: apiKey.toSafeJSON() });
+    })
+  );
+
+  /**
+   * @route DELETE /api/api-keys/:id
+   * @desc  Delete the API key and all associated usage records.
+   */
+  router.delete(
+    '/:id',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const apiKey = await findOwnedKey(req.params.id, req.user.publicKey);
+      await ApiUsage.deleteMany({ apiKeyId: apiKey._id });
+      await apiKey.deleteOne();
+
+      res.json({ success: true });
+    })
+  );
+
+  /**
+   * @route GET /api/api-keys/:id/usage
+   * @desc  Aggregated usage stats for a key over the given window.
+   * @query {string} [from] - ISO timestamp, defaults to 24h ago
+   * @query {string} [to]   - ISO timestamp, defaults to now
+   */
+  router.get(
+    '/:id/usage',
+    authenticate,
+    asyncHandler(async (req, res) => {
+      const apiKey = await findOwnedKey(req.params.id, req.user.publicKey);
+
+      const to = req.query.to ? new Date(req.query.to) : new Date();
+      const from = req.query.from
+        ? new Date(req.query.from)
+        : new Date(to.getTime() - 24 * 60 * 60 * 1000);
+
+      if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+        throw new AppError(
+          'Invalid from/to timestamp',
+          400,
+          'VALIDATION_ERROR'
+        );
+      }
+
+      const match = {
+        apiKeyId: apiKey._id,
+        timestamp: { $gte: from, $lte: to },
+      };
+
+      const [totalRequests, statusBreakdown, pathBreakdown] = await Promise.all(
+        [
+          ApiUsage.countDocuments(match),
+          ApiUsage.aggregate([
+            { $match: match },
+            { $group: { _id: '$statusCode', count: { $sum: 1 } } },
+            { $sort: { _id: 1 } },
+          ]),
+          ApiUsage.aggregate([
+            { $match: match },
+            {
+              $group: {
+                _id: { method: '$method', path: '$path' },
+                count: { $sum: 1 },
+                avgDurationMs: { $avg: '$durationMs' },
+              },
+            },
+            { $sort: { count: -1 } },
+            { $limit: 20 },
+          ]),
+        ]
+      );
+
+      res.json({
+        success: true,
+        data: {
+          apiKeyId: apiKey._id,
+          from,
+          to,
+          totalRequests,
+          byStatus: statusBreakdown.map((row) => ({
+            statusCode: row._id,
+            count: row.count,
+          })),
+          topEndpoints: pathBreakdown.map((row) => ({
+            method: row._id.method,
+            path: row._id.path,
+            count: row.count,
+            avgDurationMs: Math.round(row.avgDurationMs || 0),
+          })),
+          rateLimit: apiKey.getRateLimit(),
+        },
+      });
+    })
+  );
+
+  return router;
+};
+
+module.exports = createApiKeyRouter();
+module.exports.createApiKeyRouter = createApiKeyRouter;

--- a/server/routes/developer-gateway-routes.js
+++ b/server/routes/developer-gateway-routes.js
@@ -1,0 +1,157 @@
+const express = require('express');
+const Token = require('../models/Token');
+const { apiKeyAuth } = require('../middleware/api-key-auth');
+const { asyncHandler, AppError } = require('../middleware/error-handler');
+const { logger } = require('../utils/logger');
+
+/**
+ * @title Developer API Gateway Routes
+ * @author SoroMint Team
+ * @notice Public-facing API surface consumed by third-party developers who
+ *         integrate SoroMint into their own products. All routes require a
+ *         valid API key provided via the `X-API-Key` header and are subject
+ *         to per-key rate limiting and usage tracking.
+ *
+ *         Mount this router under `/api/v1/developer` so that versioning is
+ *         preserved independently of the main application API.
+ */
+
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 25;
+
+const parsePositiveInt = (value, fallback, { max } = {}) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  if (max && parsed > max) {
+    return max;
+  }
+  return parsed;
+};
+
+const createDeveloperGatewayRouter = () => {
+  const router = express.Router();
+
+  /**
+   * @route GET /api/v1/developer/health
+   * @desc  Simple authenticated ping for integrators to verify credentials
+   *        and connectivity. Consumes one call against the key's quota.
+   */
+  router.get(
+    '/health',
+    apiKeyAuth(),
+    asyncHandler(async (req, res) => {
+      res.json({
+        success: true,
+        data: {
+          status: 'ok',
+          apiVersion: 'v1',
+          keyPrefix: req.apiKey.prefix,
+          scopes: req.apiKey.scopes,
+          tier: req.apiKey.tier,
+          rateLimit: req.apiKey.getRateLimit(),
+          serverTime: new Date().toISOString(),
+        },
+      });
+    })
+  );
+
+  /**
+   * @route GET /api/v1/developer/tokens
+   * @desc  List tokens owned by the key's owner, with pagination.
+   */
+  router.get(
+    '/tokens',
+    apiKeyAuth({ requiredScopes: ['tokens:read'] }),
+    asyncHandler(async (req, res) => {
+      const page = parsePositiveInt(req.query.page, 1);
+      const limit = parsePositiveInt(req.query.limit, DEFAULT_PAGE_SIZE, {
+        max: MAX_PAGE_SIZE,
+      });
+      const skip = (page - 1) * limit;
+
+      const filter = { ownerPublicKey: req.apiKeyOwnerPublicKey };
+
+      const [tokens, totalCount] = await Promise.all([
+        Token.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit),
+        Token.countDocuments(filter),
+      ]);
+
+      res.json({
+        success: true,
+        data: tokens,
+        metadata: {
+          page,
+          limit,
+          totalCount,
+          totalPages: Math.ceil(totalCount / limit),
+        },
+      });
+    })
+  );
+
+  /**
+   * @route GET /api/v1/developer/tokens/:id
+   * @desc  Fetch a single token by id (scoped to the key's owner).
+   */
+  router.get(
+    '/tokens/:id',
+    apiKeyAuth({ requiredScopes: ['tokens:read'] }),
+    asyncHandler(async (req, res) => {
+      const token = await Token.findOne({
+        _id: req.params.id,
+        ownerPublicKey: req.apiKeyOwnerPublicKey,
+      });
+
+      if (!token) {
+        throw new AppError('Token not found', 404, 'NOT_FOUND');
+      }
+
+      res.json({ success: true, data: token });
+    })
+  );
+
+  /**
+   * @route POST /api/v1/developer/tokens
+   * @desc  Register a previously-deployed token for the key's owner.
+   *        Deployment itself still happens on-chain — this endpoint records
+   *        the contract in SoroMint's index.
+   */
+  router.post(
+    '/tokens',
+    apiKeyAuth({ requiredScopes: ['tokens:write'] }),
+    asyncHandler(async (req, res) => {
+      const { name, symbol, decimals, contractId } = req.body || {};
+
+      if (!name || !symbol || !contractId) {
+        throw new AppError(
+          'name, symbol and contractId are required',
+          400,
+          'VALIDATION_ERROR'
+        );
+      }
+
+      const token = await Token.create({
+        name,
+        symbol,
+        decimals,
+        contractId,
+        ownerPublicKey: req.apiKeyOwnerPublicKey,
+      });
+
+      logger.info('Developer API registered token', {
+        correlationId: req.correlationId,
+        apiKeyId: req.apiKey._id.toString(),
+        tokenId: token._id.toString(),
+      });
+
+      res.status(201).json({ success: true, data: token });
+    })
+  );
+
+  return router;
+};
+
+module.exports = createDeveloperGatewayRouter();
+module.exports.createDeveloperGatewayRouter = createDeveloperGatewayRouter;

--- a/server/tests/routes/api-key-routes.test.js
+++ b/server/tests/routes/api-key-routes.test.js
@@ -1,0 +1,259 @@
+const request = require('supertest');
+const express = require('express');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const User = require('../../models/User');
+const ApiKey = require('../../models/ApiKey');
+const ApiUsage = require('../../models/ApiUsage');
+const { generateToken } = require('../../middleware/auth');
+const { errorHandler } = require('../../middleware/error-handler');
+const apiKeyRoutes = require('../../routes/api-key-routes');
+
+const TEST_PUBLIC_KEY =
+  'GDZYF2MVD4MMJIDNVTVCKRWP7F55N56CGKUCLH7SZ7KJQLGMMFMNVOVP';
+const OTHER_PUBLIC_KEY =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB';
+
+let mongoServer;
+let app;
+let validToken;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+
+  process.env.JWT_SECRET = 'test-secret-key-for-api-key-tests';
+  process.env.JWT_EXPIRES_IN = '1h';
+
+  await User.create({ publicKey: TEST_PUBLIC_KEY, username: 'devuser' });
+  validToken = generateToken(TEST_PUBLIC_KEY, 'devuser');
+
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.correlationId = 'test-id';
+    next();
+  });
+  app.use('/api/api-keys', apiKeyRoutes);
+  app.use(errorHandler);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await ApiKey.deleteMany({});
+  await ApiUsage.deleteMany({});
+});
+
+describe('POST /api/api-keys', () => {
+  it('creates an API key and returns plaintext exactly once', async () => {
+    const res = await request(app)
+      .post('/api/api-keys')
+      .set('Authorization', `Bearer ${validToken}`)
+      .send({
+        name: 'my-key',
+        tier: 'pro',
+        scopes: ['tokens:read', 'tokens:write'],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.key).toMatch(/^sm_/);
+    expect(res.body.data.prefix).toBe(res.body.data.key.slice(0, 11));
+    expect(res.body.data.tier).toBe('pro');
+    expect(res.body.data.scopes).toEqual(
+      expect.arrayContaining(['tokens:read', 'tokens:write'])
+    );
+
+    const stored = await ApiKey.findById(res.body.data.id);
+    expect(stored).not.toBeNull();
+    expect(stored.keyHash).toBe(ApiKey.hashKey(res.body.data.key));
+  });
+
+  it('rejects invalid scopes', async () => {
+    const res = await request(app)
+      .post('/api/api-keys')
+      .set('Authorization', `Bearer ${validToken}`)
+      .send({ name: 'bad', scopes: ['nope'] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app)
+      .post('/api/api-keys')
+      .send({ name: 'my-key' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/api-keys', () => {
+  it('lists only the caller keys and omits secrets', async () => {
+    await ApiKey.create({
+      ownerPublicKey: TEST_PUBLIC_KEY,
+      name: 'mine',
+      prefix: 'sm_abc12345',
+      keyHash: ApiKey.hashKey('sm_mine_plain_value_1234567890'),
+    });
+    await ApiKey.create({
+      ownerPublicKey: OTHER_PUBLIC_KEY,
+      name: 'someone-else',
+      prefix: 'sm_xyz12345',
+      keyHash: ApiKey.hashKey('sm_other_plain_value_1234567890'),
+    });
+
+    const res = await request(app)
+      .get('/api/api-keys')
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe('mine');
+    expect(res.body.data[0].keyHash).toBeUndefined();
+  });
+});
+
+describe('POST /api/api-keys/:id/rotate', () => {
+  it('rotates the key and returns a new plaintext', async () => {
+    const originalPlain = ApiKey.generatePlaintext();
+    const key = await ApiKey.create({
+      ownerPublicKey: TEST_PUBLIC_KEY,
+      name: 'rotate-me',
+      prefix: ApiKey.derivePrefix(originalPlain),
+      keyHash: ApiKey.hashKey(originalPlain),
+    });
+
+    const res = await request(app)
+      .post(`/api/api-keys/${key._id}/rotate`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.key).toMatch(/^sm_/);
+
+    const refreshed = await ApiKey.findById(key._id);
+    expect(refreshed.keyHash).toBe(ApiKey.hashKey(res.body.data.key));
+    expect(refreshed.keyHash).not.toBe(ApiKey.hashKey(originalPlain));
+  });
+});
+
+describe('POST /api/api-keys/:id/revoke', () => {
+  it('marks the key as revoked', async () => {
+    const plain = ApiKey.generatePlaintext();
+    const key = await ApiKey.create({
+      ownerPublicKey: TEST_PUBLIC_KEY,
+      name: 'revoke-me',
+      prefix: ApiKey.derivePrefix(plain),
+      keyHash: ApiKey.hashKey(plain),
+    });
+
+    const res = await request(app)
+      .post(`/api/api-keys/${key._id}/revoke`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('revoked');
+
+    const refreshed = await ApiKey.findById(key._id);
+    expect(refreshed.status).toBe('revoked');
+  });
+});
+
+describe('DELETE /api/api-keys/:id', () => {
+  it('deletes the key and its usage records', async () => {
+    const plain = ApiKey.generatePlaintext();
+    const key = await ApiKey.create({
+      ownerPublicKey: TEST_PUBLIC_KEY,
+      name: 'doomed',
+      prefix: ApiKey.derivePrefix(plain),
+      keyHash: ApiKey.hashKey(plain),
+    });
+    await ApiUsage.create({
+      apiKeyId: key._id,
+      ownerPublicKey: TEST_PUBLIC_KEY,
+      method: 'GET',
+      path: '/api/v1/developer/tokens',
+      statusCode: 200,
+    });
+
+    const res = await request(app)
+      .delete(`/api/api-keys/${key._id}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(await ApiKey.findById(key._id)).toBeNull();
+    expect(await ApiUsage.countDocuments({ apiKeyId: key._id })).toBe(0);
+  });
+
+  it('returns 404 when the key does not belong to caller', async () => {
+    const plain = ApiKey.generatePlaintext();
+    const key = await ApiKey.create({
+      ownerPublicKey: OTHER_PUBLIC_KEY,
+      name: 'not-mine',
+      prefix: ApiKey.derivePrefix(plain),
+      keyHash: ApiKey.hashKey(plain),
+    });
+
+    const res = await request(app)
+      .delete(`/api/api-keys/${key._id}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/api-keys/:id/usage', () => {
+  it('aggregates usage for the key', async () => {
+    const plain = ApiKey.generatePlaintext();
+    const key = await ApiKey.create({
+      ownerPublicKey: TEST_PUBLIC_KEY,
+      name: 'stats',
+      prefix: ApiKey.derivePrefix(plain),
+      keyHash: ApiKey.hashKey(plain),
+    });
+
+    await ApiUsage.create([
+      {
+        apiKeyId: key._id,
+        ownerPublicKey: TEST_PUBLIC_KEY,
+        method: 'GET',
+        path: '/api/v1/developer/tokens',
+        statusCode: 200,
+        durationMs: 10,
+      },
+      {
+        apiKeyId: key._id,
+        ownerPublicKey: TEST_PUBLIC_KEY,
+        method: 'GET',
+        path: '/api/v1/developer/tokens',
+        statusCode: 200,
+        durationMs: 20,
+      },
+      {
+        apiKeyId: key._id,
+        ownerPublicKey: TEST_PUBLIC_KEY,
+        method: 'GET',
+        path: '/api/v1/developer/health',
+        statusCode: 429,
+        durationMs: 5,
+      },
+    ]);
+
+    const res = await request(app)
+      .get(`/api/api-keys/${key._id}/usage`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.totalRequests).toBe(3);
+    expect(res.body.data.byStatus).toEqual(
+      expect.arrayContaining([
+        { statusCode: 200, count: 2 },
+        { statusCode: 429, count: 1 },
+      ])
+    );
+    expect(res.body.data.topEndpoints[0].count).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/tests/routes/developer-gateway-routes.test.js
+++ b/server/tests/routes/developer-gateway-routes.test.js
@@ -1,0 +1,237 @@
+const request = require('supertest');
+const express = require('express');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const ApiKey = require('../../models/ApiKey');
+const ApiUsage = require('../../models/ApiUsage');
+const Token = require('../../models/Token');
+const { errorHandler } = require('../../middleware/error-handler');
+const { resetRateLimitBuckets } = require('../../middleware/api-key-auth');
+const developerGatewayRoutes = require('../../routes/developer-gateway-routes');
+
+const TEST_PUBLIC_KEY =
+  'GDZYF2MVD4MMJIDNVTVCKRWP7F55N56CGKUCLH7SZ7KJQLGMMFMNVOVP';
+const OTHER_PUBLIC_KEY =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB';
+
+let mongoServer;
+let app;
+
+const createKey = async (overrides = {}) => {
+  const plain = ApiKey.generatePlaintext();
+  const doc = await ApiKey.create({
+    ownerPublicKey: TEST_PUBLIC_KEY,
+    name: 'dev',
+    prefix: ApiKey.derivePrefix(plain),
+    keyHash: ApiKey.hashKey(plain),
+    scopes: ['tokens:read', 'tokens:write'],
+    tier: 'pro',
+    ...overrides,
+  });
+  return { doc, plain };
+};
+
+const flushUsage = async () => {
+  // Usage is recorded on res 'finish' which fires after supertest resolves,
+  // but the insertion is async; give the event loop a tick.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setTimeout(resolve, 50));
+};
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.correlationId = 'test-id';
+    next();
+  });
+  app.use('/api/v1/developer', developerGatewayRoutes);
+  app.use(errorHandler);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await ApiKey.deleteMany({});
+  await ApiUsage.deleteMany({});
+  await Token.deleteMany({});
+  resetRateLimitBuckets();
+});
+
+describe('Developer API Gateway authentication', () => {
+  it('rejects requests without an API key', async () => {
+    const res = await request(app).get('/api/v1/developer/health');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('API_KEY_REQUIRED');
+  });
+
+  it('rejects invalid API keys', async () => {
+    const res = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', 'sm_totally_bogus_value');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_API_KEY');
+  });
+
+  it('rejects revoked API keys', async () => {
+    const { plain } = await createKey({ status: 'revoked' });
+
+    const res = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', plain);
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('API_KEY_REVOKED');
+  });
+
+  it('rejects expired API keys', async () => {
+    const { plain } = await createKey({
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const res = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', plain);
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('API_KEY_EXPIRED');
+  });
+
+  it('accepts API keys via Authorization: ApiKey <value>', async () => {
+    const { plain } = await createKey();
+
+    const res = await request(app)
+      .get('/api/v1/developer/health')
+      .set('Authorization', `ApiKey ${plain}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('ok');
+  });
+
+  it('enforces required scopes', async () => {
+    const { plain } = await createKey({ scopes: ['tokens:read'] });
+
+    const res = await request(app)
+      .post('/api/v1/developer/tokens')
+      .set('X-API-Key', plain)
+      .send({
+        name: 'Scoped Token',
+        symbol: 'SCP',
+        contractId: `C${'A'.repeat(55)}`,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('INSUFFICIENT_SCOPE');
+  });
+});
+
+describe('Developer API Gateway rate limiting', () => {
+  it('returns 429 once the per-key limit is exceeded', async () => {
+    const { plain } = await createKey({
+      rateLimit: { windowMs: 60_000, max: 2 },
+    });
+
+    const first = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', plain);
+    const second = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', plain);
+    const third = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', plain);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    expect(third.body.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(third.headers['x-ratelimit-limit']).toBe('2');
+    expect(third.headers['x-ratelimit-remaining']).toBe('0');
+    expect(third.headers['retry-after']).toBeDefined();
+  });
+
+  it('exposes rate-limit headers on successful responses', async () => {
+    const { plain } = await createKey({
+      rateLimit: { windowMs: 60_000, max: 5 },
+    });
+
+    const res = await request(app)
+      .get('/api/v1/developer/health')
+      .set('X-API-Key', plain);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-ratelimit-limit']).toBe('5');
+    expect(res.headers['x-ratelimit-remaining']).toBe('4');
+  });
+});
+
+describe('Developer API Gateway token endpoints', () => {
+  it('scopes list results to the key owner', async () => {
+    const { plain } = await createKey();
+
+    await Token.create({
+      name: 'Mine',
+      symbol: 'MIN',
+      contractId: `C${'A'.repeat(55)}`,
+      ownerPublicKey: TEST_PUBLIC_KEY,
+    });
+    await Token.create({
+      name: 'NotMine',
+      symbol: 'NOT',
+      contractId: `C${'B'.repeat(55)}`,
+      ownerPublicKey: OTHER_PUBLIC_KEY,
+    });
+
+    const res = await request(app)
+      .get('/api/v1/developer/tokens')
+      .set('X-API-Key', plain);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].symbol).toBe('MIN');
+    expect(res.body.metadata.totalCount).toBe(1);
+  });
+
+  it('creates a token when the key has tokens:write', async () => {
+    const { plain } = await createKey();
+
+    const res = await request(app)
+      .post('/api/v1/developer/tokens')
+      .set('X-API-Key', plain)
+      .send({
+        name: 'Created Via API',
+        symbol: 'CVA',
+        contractId: `C${'C'.repeat(55)}`,
+        decimals: 7,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.ownerPublicKey).toBe(TEST_PUBLIC_KEY);
+  });
+});
+
+describe('Developer API Gateway usage tracking', () => {
+  it('records usage after a successful request', async () => {
+    const { doc, plain } = await createKey();
+
+    await request(app).get('/api/v1/developer/health').set('X-API-Key', plain);
+
+    await flushUsage();
+
+    const usage = await ApiUsage.find({ apiKeyId: doc._id });
+    expect(usage.length).toBe(1);
+    expect(usage[0].method).toBe('GET');
+    expect(usage[0].statusCode).toBe(200);
+
+    const refreshed = await ApiKey.findById(doc._id);
+    expect(refreshed.usageCount).toBe(1);
+    expect(refreshed.lastUsedAt).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## Summary

Added a Developer API Gateway with API key management, per-key rate limiting, and usage tracking.

New modules (all in `server/`):

- `models/ApiKey.js` – Mongoose model storing SHA-256-hashed API keys with owner, non-secret prefix, tier (free/pro/enterprise), scopes (`tokens:read`, `tokens:write`, `analytics:read`), optional per-key rate-limit override, status (active/revoked), optional `expiresAt`, `lastUsedAt`, `usageCount`. Provides `generatePlaintext`, `hashKey`, `derivePrefix`, `findByPlaintext`, `getRateLimit`, `isUsable`, and `toSafeJSON` (never leaks the hash).

- `models/ApiUsage.js` – Per-request usage log (method, path, status, duration, ip, UA) with compound index and a 90-day TTL index.

- `middleware/api-key-auth.js` – Express middleware that authenticates via `X-API-Key` or `Authorization: ApiKey <key>`, validates status/expiry/required scopes (returning `API_KEY_REQUIRED`, `INVALID_API_KEY`, `API_KEY_REVOKED`, `API_KEY_EXPIRED`, `INSUFFICIENT_SCOPE`), enforces an in-memory sliding-window rate limit driven by tier defaults or per-key overrides while emitting standard `X-RateLimit-*` + `Retry-After` headers, and records `ApiUsage` on `res.finish` plus updates `lastUsedAt`/`usageCount`.

- `routes/api-key-routes.js` – JWT-protected CRUD under `/api/api-keys` for users to create (plaintext returned exactly once), list, get, patch, rotate, revoke, delete, and inspect `GET /:id/usage` (totals, status breakdown, top endpoints, effective rate limit).

- `routes/developer-gateway-routes.js` – Public developer gateway under `/api/v1/developer` protected by `apiKeyAuth` with `GET /health`, `GET /tokens`, `GET /tokens/:id`, `POST /tokens`, each enforcing appropriate scopes and scoping data to the key's owner.

- `index.js` – Registers the new routers.

Tests (20 total, all passing in ~5s):
- `tests/routes/api-key-routes.test.js` – create/list/rotate/revoke/delete/usage including authorization and scope-validation paths.
- `tests/routes/developer-gateway-routes.test.js` – missing/invalid/revoked/expired keys, scope enforcement, rate-limit exhaustion with response headers, data scoping to owner, usage-record creation.

Pre-existing failures not caused by this change (verified by re-running on the base branch):
- `npm run lint` — repository-level: `.eslintrc.json` is present but ESLint v10 requires `eslint.config.js`. Same error on main.
- `npm test` timeout — the full Jest suite times out on main as well; it is unrelated to the new tests, which complete in ~5 seconds in isolation. Other currently-failing suites (`tests/index.test.js`, `tests/routes/webhook-routes.test.js`, `tests/routes/rate-limited-routes.test.js`) fail identically on main.

---

closes #177