### PR TITLE
Add analytics API endpoints for transfer, holder, volume, and combined token metrics

### DIFF
--- a/ANALYTICS_ENDPOINTS_TESTING.md
+++ b/ANALYTICS_ENDPOINTS_TESTING.md
@@ -1,0 +1,322 @@
+# Analytics Endpoints Testing Guide
+
+## Overview
+This guide provides step-by-step instructions to test the newly implemented analytics endpoints that aggregate transfer data, holder distribution, and volume metrics for all tokens minted via the SoroMint platform.
+
+## Prerequisites
+1. Backend server running: `cd server && npm run dev`
+2. MongoDB running: `docker-compose up -d`
+3. Valid JWT authentication token (obtain from login endpoint)
+4. Sample token data with transfer events in the database
+
+## Endpoints Implemented
+
+### 1. Transfer Aggregation Endpoint
+**Endpoint:** `GET /api/analytics/transfers`
+**Authentication:** Required (JWT)
+**Description:** Aggregates transfer data for all tokens
+
+#### Testing Steps:
+```bash
+# Replace YOUR_TOKEN with actual JWT
+curl -X GET http://localhost:5000/api/analytics/transfers \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+#### Expected Response:
+```json
+{
+  "success": true,
+  "data": {
+    "exportedAt": "2024-04-24T12:00:00.000Z",
+    "summary": {
+      "totalTransfers": 150,
+      "totalUniqueTransferers": 45,
+      "tokensWithTransfers": 8
+    },
+    "transfers": [
+      {
+        "contractId": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+        "tokenName": "SoroMint Token",
+        "symbol": "SORO",
+        "decimals": 7,
+        "transferCount": 25,
+        "uniqueTransferers": 12,
+        "totalVolume": "5000000000",
+        "lastTransferAt": "2024-04-24T10:30:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+### 2. Holder Distribution Endpoint
+**Endpoint:** `GET /api/analytics/holders`
+**Authentication:** Required (JWT)
+**Description:** Returns holder distribution data for all tokens
+
+#### Testing Steps:
+```bash
+curl -X GET http://localhost:5000/api/analytics/holders \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+#### Expected Response:
+```json
+{
+  "success": true,
+  "data": {
+    "exportedAt": "2024-04-24T12:00:00.000Z",
+    "summary": {
+      "totalUniquePlatformHolders": 89,
+      "tokensWithHolders": 8,
+      "averageHoldersPerToken": 11
+    },
+    "holders": [
+      {
+        "contractId": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+        "tokenName": "SoroMint Token",
+        "symbol": "SORO",
+        "decimals": 7,
+        "uniqueHolders": 23,
+        "topHolderCount": 10
+      }
+    ]
+  }
+}
+```
+
+### 3. Volume Metrics Endpoint
+**Endpoint:** `GET /api/analytics/volume?days=30`
+**Authentication:** Required (JWT)
+**Query Parameters:**
+- `days` (optional, default: 30): Number of days to analyze (1-365)
+
+**Description:** Returns volume metrics for all tokens including 24h, 7d, and 30d volumes
+
+#### Testing Steps:
+```bash
+# Using default 30 days
+curl -X GET http://localhost:5000/api/analytics/volume \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json"
+
+# Using custom period (7 days)
+curl -X GET "http://localhost:5000/api/analytics/volume?days=7" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+#### Expected Response:
+```json
+{
+  "success": true,
+  "data": {
+    "exportedAt": "2024-04-24T12:00:00.000Z",
+    "period": {
+      "days": 30,
+      "startDate": "2024-03-25T12:00:00.000Z"
+    },
+    "summary": {
+      "totalPlatformVolume30d": "125000000000",
+      "volumeMetricsTokens": 8
+    },
+    "volumes": [
+      {
+        "contractId": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+        "tokenName": "SoroMint Token",
+        "symbol": "SORO",
+        "decimals": 7,
+        "volume24h": "5000000",
+        "volume7d": "35000000",
+        "volume30d": "120000000",
+        "dailyAverage": "4000000",
+        "transferCount30d": 45,
+        "avgTransferSize": "2666666"
+      }
+    ]
+  }
+}
+```
+
+### 4. Comprehensive Metrics Endpoint
+**Endpoint:** `GET /api/analytics/metrics?days=30`
+**Authentication:** Required (JWT)
+**Query Parameters:**
+- `days` (optional, default: 30): Number of days for volume analysis (1-365)
+
+**Description:** Comprehensive token metrics combining transfers, holders, and volume data
+
+#### Testing Steps:
+```bash
+# Using default 30 days
+curl -X GET http://localhost:5000/api/analytics/metrics \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json"
+
+# Using custom period (14 days)
+curl -X GET "http://localhost:5000/api/analytics/metrics?days=14" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+#### Expected Response:
+```json
+{
+  "success": true,
+  "data": {
+    "exportedAt": "2024-04-24T12:00:00.000Z",
+    "volumePeriod": {
+      "days": 30,
+      "startDate": "2024-03-25T12:00:00.000Z"
+    },
+    "platformSummary": {
+      "totalTokens": 10,
+      "totalTransfers": 150,
+      "totalUniqueTransferers": 45,
+      "totalUniquePlatformHolders": 89,
+      "totalPlatformVolume30d": "125000000000",
+      "tokensWithActivity": 8
+    },
+    "tokens": [
+      {
+        "contractId": "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+        "tokenName": "SoroMint Token",
+        "symbol": "SORO",
+        "decimals": 7,
+        "transferCount": 25,
+        "uniqueTransferers": 12,
+        "totalVolume": "120000000",
+        "lastTransferAt": "2024-04-24T10:30:00.000Z",
+        "uniqueHolders": 23,
+        "topHolderCount": 10,
+        "volume24h": "5000000",
+        "volume7d": "35000000",
+        "volume30d": "120000000",
+        "dailyAverage": "4000000",
+        "transferCount30d": 45,
+        "avgTransferSize": "2666666"
+      }
+    ]
+  }
+}
+```
+
+## Testing with Node.js Script
+
+Create a test file `test-analytics.js`:
+
+```javascript
+const axios = require('axios');
+
+const BASE_URL = 'http://localhost:5000/api';
+const TOKEN = 'YOUR_JWT_TOKEN';
+
+const headers = {
+  'Authorization': `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json'
+};
+
+async function testEndpoints() {
+  try {
+    console.log('Testing Transfer Aggregation...');
+    const transfers = await axios.get(`${BASE_URL}/analytics/transfers`, { headers });
+    console.log('✓ Transfers:', JSON.stringify(transfers.data, null, 2));
+
+    console.log('\nTesting Holder Distribution...');
+    const holders = await axios.get(`${BASE_URL}/analytics/holders`, { headers });
+    console.log('✓ Holders:', JSON.stringify(holders.data, null, 2));
+
+    console.log('\nTesting Volume Metrics (30 days)...');
+    const volume30 = await axios.get(`${BASE_URL}/analytics/volume?days=30`, { headers });
+    console.log('✓ Volume (30d):', JSON.stringify(volume30.data, null, 2));
+
+    console.log('\nTesting Volume Metrics (7 days)...');
+    const volume7 = await axios.get(`${BASE_URL}/analytics/volume?days=7`, { headers });
+    console.log('✓ Volume (7d):', JSON.stringify(volume7.data, null, 2));
+
+    console.log('\nTesting Comprehensive Metrics...');
+    const metrics = await axios.get(`${BASE_URL}/analytics/metrics?days=30`, { headers });
+    console.log('✓ Metrics:', JSON.stringify(metrics.data, null, 2));
+
+    console.log('\n✅ All tests passed!');
+  } catch (error) {
+    console.error('❌ Test failed:', error.response?.data || error.message);
+  }
+}
+
+testEndpoints();
+```
+
+Run it with:
+```bash
+node test-analytics.js
+```
+
+## Data Validation Checklist
+
+After running the endpoints, verify:
+
+- [ ] All endpoints return HTTP 200 with `success: true`
+- [ ] `exportedAt` timestamps are valid ISO 8601 dates
+- [ ] Transfer counts are non-negative integers
+- [ ] Volume values are valid big integers (as strings)
+- [ ] Holder counts are non-negative integers
+- [ ] Token contract IDs are present and unique per token
+- [ ] All token symbols, names, and decimals match database records
+- [ ] Volume metrics show logical progression: volume24h ≤ volume7d ≤ volume30d
+- [ ] Average values are mathematically correct (volume divided by count)
+- [ ] Last transfer dates are within the analysis period
+- [ ] Platform summary aggregations match individual token sums
+
+## Performance Testing
+
+Test endpoint response times with larger datasets:
+
+```bash
+# Time the metrics endpoint
+time curl -X GET "http://localhost:5000/api/analytics/metrics" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Acceptable response time: < 2 seconds for datasets with 50+ tokens
+```
+
+## Integration Testing
+
+### Test with External Dashboards:
+1. Export metrics to Dune Analytics (if configured)
+2. Verify data appears in Dune tables
+3. Test webhook sync endpoint: `POST /api/analytics/sync`
+
+### Test Edge Cases:
+1. **No tokens:** Verify endpoints return empty arrays with zero totals
+2. **No transfers:** Verify endpoints handle tokens with no transfer events
+3. **Invalid days parameter:** Test with days=0, days=366, days=-1 (should be constrained to 1-365)
+4. **Authentication:** Test without JWT token (should return 401)
+
+## Troubleshooting
+
+### Empty results
+- Verify MongoDB has sample SorobanEvent records
+- Check that contractIds in events match Token contractIds
+- Ensure eventType contains "transfer" keyword
+
+### Performance issues
+- Add database indexes: `db.sorobanevents.createIndex({ contractId: 1, eventType: 1 })`
+- Consider pagination for large datasets in future versions
+
+### Authorization errors
+- Verify JWT token is valid and not expired
+- Check authentication middleware configuration
+
+## Success Criteria
+
+Your implementation is complete when:
+1. ✅ All 5 endpoints respond with data in expected format
+2. ✅ No authorization errors occur
+3. ✅ Data aggregations are mathematically correct
+4. ✅ Response times are acceptable (< 2s)
+5. ✅ All edge cases handled gracefully
+6. ✅ Linting and code validation passes

--- a/server/routes/analytics-routes.js
+++ b/server/routes/analytics-routes.js
@@ -8,7 +8,14 @@
 const express = require("express");
 const { asyncHandler } = require("../middleware/error-handler");
 const { authenticate } = require("../middleware/auth");
-const { syncAnalytics, buildAnalyticsPayload } = require("../services/analytics-service");
+const { 
+  syncAnalytics, 
+  buildAnalyticsPayload,
+  getTransferAggregation,
+  getHolderDistribution,
+  getVolumeMetrics,
+  getTokensMetrics,
+} = require("../services/analytics-service");
 const { logger } = require("../utils/logger");
 
 const router = express.Router();
@@ -44,6 +51,87 @@ router.post(
     logger.info("Analytics sync triggered", { correlationId: req.correlationId });
     const result = await syncAnalytics();
     res.json({ success: true, data: result });
+  })
+);
+
+/**
+ * @route GET /api/analytics/transfers
+ * @description Aggregates transfer data for all tokens minted via the platform.
+ *   Returns transfer counts, unique transferers, and total volumes per token.
+ * @security JWT
+ * @returns {Object} 200 - Transfer aggregation data
+ */
+router.get(
+  "/analytics/transfers",
+  authenticate,
+  asyncHandler(async (req, res) => {
+    logger.info("Transfer aggregation requested", { correlationId: req.correlationId });
+    const data = await getTransferAggregation();
+    res.json({ success: true, data });
+  })
+);
+
+/**
+ * @route GET /api/analytics/holders
+ * @description Returns holder distribution data for all tokens.
+ *   Shows unique holders per token and platform-wide holder metrics.
+ * @security JWT
+ * @returns {Object} 200 - Holder distribution data
+ */
+router.get(
+  "/analytics/holders",
+  authenticate,
+  asyncHandler(async (req, res) => {
+    logger.info("Holder distribution requested", { correlationId: req.correlationId });
+    const data = await getHolderDistribution();
+    res.json({ success: true, data });
+  })
+);
+
+/**
+ * @route GET /api/analytics/volume
+ * @description Returns volume metrics for all tokens including 24h, 7d, and 30d volumes.
+ *   Optional query parameter 'days' controls the analysis period (default: 30).
+ * @security JWT
+ * @query {number} [days=30] - Number of days to analyze
+ * @returns {Object} 200 - Volume metrics data
+ */
+router.get(
+  "/analytics/volume",
+  authenticate,
+  asyncHandler(async (req, res) => {
+    const { days = 30 } = req.query;
+    const daysNum = Math.max(1, Math.min(365, parseInt(days, 10) || 30));
+    logger.info("Volume metrics requested", { 
+      correlationId: req.correlationId,
+      days: daysNum,
+    });
+    const data = await getVolumeMetrics(daysNum);
+    res.json({ success: true, data });
+  })
+);
+
+/**
+ * @route GET /api/analytics/metrics
+ * @description Comprehensive token metrics combining transfers, holders, and volume data.
+ *   Provides a complete platform analytics snapshot.
+ *   Optional query parameter 'days' controls volume analysis period (default: 30).
+ * @security JWT
+ * @query {number} [days=30] - Number of days for volume analysis
+ * @returns {Object} 200 - Comprehensive token metrics
+ */
+router.get(
+  "/analytics/metrics",
+  authenticate,
+  asyncHandler(async (req, res) => {
+    const { days = 30 } = req.query;
+    const daysNum = Math.max(1, Math.min(365, parseInt(days, 10) || 30));
+    logger.info("Comprehensive metrics requested", { 
+      correlationId: req.correlationId,
+      days: daysNum,
+    });
+    const data = await getTokensMetrics(daysNum);
+    res.json({ success: true, data });
   })
 );
 

--- a/server/services/analytics-service.js
+++ b/server/services/analytics-service.js
@@ -10,6 +10,7 @@ const http = require("http");
 const { URL } = require("url");
 const Token = require("../models/Token");
 const DeploymentAudit = require("../models/DeploymentAudit");
+const SorobanEvent = require("../models/SorobanEvent");
 const { logger } = require("../utils/logger");
 
 /**
@@ -180,4 +181,296 @@ async function syncAnalytics() {
   return { exportedAt: payload.exportedAt, summary: payload.summary, results };
 }
 
-module.exports = { syncAnalytics, buildAnalyticsPayload };
+/**
+ * Aggregate transfer data for all tokens minted via the platform.
+ * Queries SorobanEvent records with eventType containing 'transfer' patterns.
+ * @returns {Promise<Object>} transfer aggregation data
+ */
+async function getTransferAggregation() {
+  try {
+    // Get all tokens in the system
+    const tokens = await Token.find({}).select("contractId name symbol decimals").lean();
+    
+    const transferData = [];
+    let totalTransfers = 0;
+    let totalUniqueTransferers = new Set();
+
+    for (const token of tokens) {
+      // Find all transfer events for this token
+      const transfers = await SorobanEvent.find({
+        contractId: token.contractId,
+        eventType: { $regex: "transfer", $options: "i" },
+      }).lean();
+
+      const transferCount = transfers.length;
+      totalTransfers += transferCount;
+
+      // Extract unique senders from topics/value
+      const uniqueSenders = new Set();
+      transfers.forEach((event) => {
+        if (event.topics && event.topics.length > 0) {
+          uniqueSenders.add(event.topics[0]);
+          totalUniqueTransferers.add(event.topics[0]);
+        }
+      });
+
+      // Calculate total volume from all transfers
+      let totalVolume = 0n;
+      transfers.forEach((event) => {
+        if (event.value && typeof event.value === "object" && event.value.amount) {
+          try {
+            totalVolume += BigInt(event.value.amount || 0);
+          } catch (e) {
+            // Skip invalid parsing
+          }
+        }
+      });
+
+      transferData.push({
+        contractId: token.contractId,
+        tokenName: token.name,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        transferCount,
+        uniqueTransferers: uniqueSenders.size,
+        totalVolume: totalVolume.toString(),
+        lastTransferAt: transfers.length > 0 
+          ? new Date(Math.max(...transfers.map(t => new Date(t.ledgerClosedAt).getTime())))
+          : null,
+      });
+    }
+
+    return {
+      exportedAt: new Date().toISOString(),
+      summary: {
+        totalTransfers,
+        totalUniqueTransferers: totalUniqueTransferers.size,
+        tokensWithTransfers: transferData.filter(t => t.transferCount > 0).length,
+      },
+      transfers: transferData,
+    };
+  } catch (error) {
+    logger.error("Error getting transfer aggregation", { error: error.message });
+    throw error;
+  }
+}
+
+/**
+ * Get holder distribution across all tokens.
+ * Aggregates unique holders per token based on transfer events.
+ * @returns {Promise<Object>} holder distribution data
+ */
+async function getHolderDistribution() {
+  try {
+    const tokens = await Token.find({}).select("contractId name symbol decimals").lean();
+    
+    const holderData = [];
+    let totalHolders = new Set();
+
+    for (const token of tokens) {
+      // Find all transfer events involving this token
+      const transfers = await SorobanEvent.find({
+        contractId: token.contractId,
+        eventType: { $regex: "transfer", $options: "i" },
+      }).lean();
+
+      // Extract unique recipients (typically second topic) and senders (first topic)
+      const uniqueHolders = new Set();
+      transfers.forEach((event) => {
+        if (event.topics && event.topics.length > 0) {
+          uniqueHolders.add(event.topics[0]); // sender
+          if (event.topics.length > 1) {
+            uniqueHolders.add(event.topics[1]); // recipient
+          }
+        }
+      });
+
+      uniqueHolders.forEach(holder => totalHolders.add(holder));
+
+      holderData.push({
+        contractId: token.contractId,
+        tokenName: token.name,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        uniqueHolders: uniqueHolders.size,
+        topHolderCount: Math.min(10, uniqueHolders.size), // Can be extended to track top holders
+      });
+    }
+
+    return {
+      exportedAt: new Date().toISOString(),
+      summary: {
+        totalUniquePlatformHolders: totalHolders.size,
+        tokensWithHolders: holderData.filter(h => h.uniqueHolders > 0).length,
+        averageHoldersPerToken: holderData.length > 0 
+          ? Math.round(holderData.reduce((sum, h) => sum + h.uniqueHolders, 0) / holderData.length)
+          : 0,
+      },
+      holders: holderData,
+    };
+  } catch (error) {
+    logger.error("Error getting holder distribution", { error: error.message });
+    throw error;
+  }
+}
+
+/**
+ * Get volume metrics for all tokens.
+ * Aggregates transfer volume and trends over time.
+ * @param {number} [days=30] - Number of days to analyze
+ * @returns {Promise<Object>} volume metrics data
+ */
+async function getVolumeMetrics(days = 30) {
+  try {
+    const tokens = await Token.find({}).select("contractId name symbol decimals").lean();
+    
+    const volumeData = [];
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - days);
+    
+    let totalPlatformVolume = 0n;
+
+    for (const token of tokens) {
+      // Get recent transfer events
+      const recentTransfers = await SorobanEvent.find({
+        contractId: token.contractId,
+        eventType: { $regex: "transfer", $options: "i" },
+        ledgerClosedAt: { $gte: cutoffDate },
+      }).sort({ ledgerClosedAt: -1 }).lean();
+
+      // Calculate volume metrics
+      let volume24h = 0n;
+      let volume7d = 0n;
+      let volume30d = 0n;
+
+      const now = new Date();
+      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+      recentTransfers.forEach((event) => {
+        let eventAmount = 0n;
+        try {
+          eventAmount = BigInt(event.value?.amount || 0);
+        } catch (e) {
+          // Skip invalid amounts
+        }
+
+        const eventDate = new Date(event.ledgerClosedAt);
+        
+        if (eventDate >= oneDayAgo) volume24h += eventAmount;
+        if (eventDate >= sevenDaysAgo) volume7d += eventAmount;
+        volume30d += eventAmount;
+      });
+
+      totalPlatformVolume += volume30d;
+
+      // Calculate daily average
+      const dailyAverage = days > 0 
+        ? (BigInt(Math.floor(Number(volume30d) / days))).toString()
+        : "0";
+
+      volumeData.push({
+        contractId: token.contractId,
+        tokenName: token.name,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        volume24h: volume24h.toString(),
+        volume7d: volume7d.toString(),
+        volume30d: volume30d.toString(),
+        dailyAverage,
+        transferCount30d: recentTransfers.length,
+        avgTransferSize: recentTransfers.length > 0
+          ? (BigInt(Math.floor(Number(volume30d) / recentTransfers.length))).toString()
+          : "0",
+      });
+    }
+
+    return {
+      exportedAt: new Date().toISOString(),
+      period: { days, startDate: cutoffDate.toISOString() },
+      summary: {
+        totalPlatformVolume30d: totalPlatformVolume.toString(),
+        volumeMetricsTokens: volumeData.filter(v => BigInt(v.volume30d) > 0n).length,
+      },
+      volumes: volumeData,
+    };
+  } catch (error) {
+    logger.error("Error getting volume metrics", { error: error.message });
+    throw error;
+  }
+}
+
+/**
+ * Get comprehensive metrics for all tokens combining transfers, holders, and volume.
+ * @param {number} [days=30] - Number of days for volume analysis
+ * @returns {Promise<Object>} comprehensive token metrics
+ */
+async function getTokensMetrics(days = 30) {
+  try {
+    const [transfers, holders, volumes] = await Promise.all([
+      getTransferAggregation(),
+      getHolderDistribution(),
+      getVolumeMetrics(days),
+    ]);
+
+    // Merge all metrics by contractId
+    const metricsMap = new Map();
+
+    // Add transfer data
+    transfers.transfers.forEach((t) => {
+      metricsMap.set(t.contractId, {
+        contractId: t.contractId,
+        tokenName: t.tokenName,
+        symbol: t.symbol,
+        decimals: t.decimals,
+        ...t,
+      });
+    });
+
+    // Merge holder data
+    holders.holders.forEach((h) => {
+      const existing = metricsMap.get(h.contractId) || {};
+      metricsMap.set(h.contractId, {
+        ...existing,
+        ...h,
+      });
+    });
+
+    // Merge volume data
+    volumes.volumes.forEach((v) => {
+      const existing = metricsMap.get(v.contractId) || {};
+      metricsMap.set(v.contractId, {
+        ...existing,
+        ...v,
+      });
+    });
+
+    const metrics = Array.from(metricsMap.values());
+
+    return {
+      exportedAt: new Date().toISOString(),
+      volumePeriod: { days, startDate: volumes.period.startDate },
+      platformSummary: {
+        totalTokens: metrics.length,
+        totalTransfers: transfers.summary.totalTransfers,
+        totalUniqueTransferers: transfers.summary.totalUniqueTransferers,
+        totalUniquePlatformHolders: holders.summary.totalUniquePlatformHolders,
+        totalPlatformVolume30d: volumes.summary.totalPlatformVolume30d,
+        tokensWithActivity: metrics.filter(m => (m.transferCount || 0) > 0).length,
+      },
+      tokens: metrics,
+    };
+  } catch (error) {
+    logger.error("Error getting comprehensive tokens metrics", { error: error.message });
+    throw error;
+  }
+}
+
+module.exports = { 
+  syncAnalytics, 
+  buildAnalyticsPayload,
+  getTransferAggregation,
+  getHolderDistribution,
+  getVolumeMetrics,
+  getTokensMetrics,
+};


### PR DESCRIPTION
Close #160 

## Summary
This PR adds new analytics endpoints to the backend to support aggregated data for all tokens minted via the platform.

## Changes
- Extended analytics-service.js with:
  - `getTransferAggregation()`
  - `getHolderDistribution()`
  - `getVolumeMetrics(days)`
  - `getTokensMetrics(days)`
- Added new authenticated API routes in analytics-routes.js:
  - `GET /api/analytics/transfers`
  - `GET /api/analytics/holders`
  - `GET /api/analytics/volume`
  - `GET /api/analytics/metrics`
- Kept existing export and sync endpoints intact.
- Added ANALYTICS_ENDPOINTS_TESTING.md with step-by-step validation instructions.

## Testing
- Run backend server and MongoDB.
- Use a valid JWT and `curl` or script to call:
  - `GET /api/analytics/transfers`
  - `GET /api/analytics/holders`
  - `GET /api/analytics/volume?days=30`
  - `GET /api/analytics/metrics?days=30`
- Validate responses include aggregated counts, holder distribution, volume metrics, and combined platform summaries.

## Notes
- Endpoints respect privacy by exposing only non-PII token identifiers and metrics.
- `days` query parameter is bounded to `1-365` for volume and metrics endpoints.
- No code changes were applied beyond analytics service and route support.