### PR TITLE
feat: add Upgradeable contract with standard upgrade function

### DIFF
--- a/contracts/upgradeable/Cargo.toml
+++ b/contracts/upgradeable/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "soromint-upgradeable"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/upgradeable/src/lib.rs
+++ b/contracts/upgradeable/src/lib.rs
@@ -1,0 +1,83 @@
+//! # SoroMint Upgradeable Contract
+//!
+//! Demonstrates the standard Soroban upgrade pattern: the admin can replace
+//! the contract's WASM while all persistent state is preserved.
+//!
+//! ## Upgrade flow
+//! 1. Deploy and call `initialize(admin)`.
+//! 2. Upload new WASM to the network, obtain its 32-byte hash.
+//! 3. Admin calls `upgrade(new_wasm_hash)` — the runtime swaps the WASM
+//!    in-place; all storage keys survive unchanged.
+
+#![no_std]
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Version,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct Upgradeable;
+
+#[contractimpl]
+impl Upgradeable {
+    /// One-time setup.
+    pub fn initialize(e: Env, admin: Address) {
+        if e.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Admin, &admin);
+        e.storage().instance().set(&DataKey::Version, &1u32);
+    }
+
+    /// Replace the contract WASM. State is preserved across the upgrade.
+    pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+        e.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+
+        let ver: u32 = e.storage().instance().get(&DataKey::Version).unwrap_or(1);
+        e.storage().instance().set(&DataKey::Version, &(ver + 1));
+
+        e.events()
+            .publish((symbol_short!("upgraded"),), new_wasm_hash);
+    }
+
+    /// Transfer admin rights to a new address.
+    pub fn set_admin(e: Env, new_admin: Address) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Admin, &new_admin);
+        e.events()
+            .publish((symbol_short!("adm_set"),), new_admin);
+    }
+
+    pub fn get_admin(e: Env) -> Address {
+        e.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    pub fn get_version(e: Env) -> u32 {
+        e.storage().instance().get(&DataKey::Version).unwrap_or(1)
+    }
+
+    pub fn version(_e: Env) -> String {
+        String::from_str(&_e, "1.0.0")
+    }
+}

--- a/contracts/upgradeable/src/test.rs
+++ b/contracts/upgradeable/src/test.rs
@@ -1,0 +1,47 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+#[test]
+fn test_initialize_and_version() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let contract_id = e.register(Upgradeable, ());
+    let client = UpgradeableClient::new(&e, &contract_id);
+
+    client.initialize(&admin);
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_version(), 1);
+}
+
+#[test]
+fn test_set_admin() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let new_admin = Address::generate(&e);
+    let contract_id = e.register(Upgradeable, ());
+    let client = UpgradeableClient::new(&e, &contract_id);
+
+    client.initialize(&admin);
+    client.set_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_double_initialize() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let contract_id = e.register(Upgradeable, ());
+    let client = UpgradeableClient::new(&e, &contract_id);
+
+    client.initialize(&admin);
+    client.initialize(&admin); // should panic
+}


### PR DESCRIPTION
Implement the standard upgrade function allowing the admin to update the contract's logic WASM while preserving state.

- Admin-gated upgrade() calls deployer().update_current_contract_wasm()
- Version counter incremented on each upgrade for auditability
- Admin transfer supported via set_admin()
- All persistent storage survives WASM replacement

Closes #199