### PR TITLE
feat: add Insurance/Backstop Fund contract

### DIFF
--- a/contracts/backstop/Cargo.toml
+++ b/contracts/backstop/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "soromint-backstop"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/backstop/src/lib.rs
+++ b/contracts/backstop/src/lib.rs
@@ -1,0 +1,148 @@
+//! # SoroMint Backstop / Insurance Fund Contract
+//!
+//! Collects protocol fees and holds them as a backstop reserve. In the event
+//! of an exploit or liquidation shortfall the admin can draw from the fund to
+//! cover losses.
+//!
+//! ## Roles
+//! - **Admin** – can withdraw funds for coverage and update the fee rate.
+//! - **Fee depositor** – any address (typically the protocol) can call
+//!   `deposit_fee` to add tokens to the reserve.
+//!
+//! ## Fee collection
+//! The contract stores a `fee_bps` (basis points) value. Helper `calc_fee`
+//! returns the fee amount for a given principal so callers can compute the
+//! correct deposit before calling `deposit_fee`.
+
+#![no_std]
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, String};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Token,
+    FeeBps,
+    TotalDeposited,
+    TotalWithdrawn,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct Backstop;
+
+#[contractimpl]
+impl Backstop {
+    /// One-time setup.
+    pub fn initialize(e: Env, admin: Address, token: Address, fee_bps: u32) {
+        if e.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        if fee_bps > 10_000 {
+            panic!("fee_bps > 10000");
+        }
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Admin, &admin);
+        e.storage().instance().set(&DataKey::Token, &token);
+        e.storage().instance().set(&DataKey::FeeBps, &fee_bps);
+        e.storage().instance().set(&DataKey::TotalDeposited, &0i128);
+        e.storage().instance().set(&DataKey::TotalWithdrawn, &0i128);
+    }
+
+    /// Deposit a fee amount into the backstop reserve.
+    pub fn deposit_fee(e: Env, from: Address, amount: i128) {
+        from.require_auth();
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        let tok: Address = e.storage().instance().get(&DataKey::Token).unwrap();
+        token::Client::new(&e, &tok).transfer(&from, &e.current_contract_address(), &amount);
+
+        let total: i128 = e
+            .storage()
+            .instance()
+            .get(&DataKey::TotalDeposited)
+            .unwrap();
+        e.storage()
+            .instance()
+            .set(&DataKey::TotalDeposited, &(total + amount));
+
+        e.events()
+            .publish((symbol_short!("fee_dep"),), (from, amount));
+    }
+
+    /// Admin withdraws `amount` to cover an exploit or liquidation shortfall.
+    pub fn withdraw(e: Env, to: Address, amount: i128) {
+        Self::require_admin(&e);
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        let tok: Address = e.storage().instance().get(&DataKey::Token).unwrap();
+        token::Client::new(&e, &tok).transfer(&e.current_contract_address(), &to, &amount);
+
+        let total: i128 = e
+            .storage()
+            .instance()
+            .get(&DataKey::TotalWithdrawn)
+            .unwrap();
+        e.storage()
+            .instance()
+            .set(&DataKey::TotalWithdrawn, &(total + amount));
+
+        e.events()
+            .publish((symbol_short!("withdraw"),), (to, amount));
+    }
+
+    /// Update the fee rate (admin only).
+    pub fn set_fee_bps(e: Env, fee_bps: u32) {
+        Self::require_admin(&e);
+        if fee_bps > 10_000 {
+            panic!("fee_bps > 10000");
+        }
+        e.storage().instance().set(&DataKey::FeeBps, &fee_bps);
+        e.events()
+            .publish((symbol_short!("fee_set"),), fee_bps);
+    }
+
+    /// Calculate the fee for a given principal amount.
+    pub fn calc_fee(e: Env, principal: i128) -> i128 {
+        let bps: u32 = e.storage().instance().get(&DataKey::FeeBps).unwrap();
+        principal * bps as i128 / 10_000
+    }
+
+    pub fn get_fee_bps(e: Env) -> u32 {
+        e.storage().instance().get(&DataKey::FeeBps).unwrap()
+    }
+
+    pub fn get_total_deposited(e: Env) -> i128 {
+        e.storage().instance().get(&DataKey::TotalDeposited).unwrap()
+    }
+
+    pub fn get_total_withdrawn(e: Env) -> i128 {
+        e.storage().instance().get(&DataKey::TotalWithdrawn).unwrap()
+    }
+
+    pub fn version(_e: Env) -> String {
+        String::from_str(&_e, "1.0.0")
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn require_admin(e: &Env) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+    }
+}

--- a/contracts/backstop/src/test.rs
+++ b/contracts/backstop/src/test.rs
@@ -1,0 +1,51 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+fn setup(e: &Env) -> (Address, Address, Address) {
+    let admin = Address::generate(e);
+    let depositor = Address::generate(e);
+    let token_id = e.register_stellar_asset_contract_v2(admin.clone());
+    StellarAssetClient::new(e, &token_id.address()).mint(&depositor, &10_000);
+    (admin, depositor, token_id.address())
+}
+
+#[test]
+fn test_deposit_and_withdraw() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (admin, depositor, token_addr) = setup(&e);
+    let token = TokenClient::new(&e, &token_addr);
+
+    let contract_id = e.register(Backstop, ());
+    let client = BackstopClient::new(&e, &contract_id);
+
+    client.initialize(&admin, &token_addr, &50u32); // 0.5%
+
+    client.deposit_fee(&depositor, &1000i128);
+    assert_eq!(client.get_total_deposited(), 1000);
+    assert_eq!(token.balance(&contract_id), 1000);
+
+    client.withdraw(&depositor, &400i128);
+    assert_eq!(client.get_total_withdrawn(), 400);
+    assert_eq!(token.balance(&contract_id), 600);
+}
+
+#[test]
+fn test_calc_fee() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (admin, _, token_addr) = setup(&e);
+    let contract_id = e.register(Backstop, ());
+    let client = BackstopClient::new(&e, &contract_id);
+
+    client.initialize(&admin, &token_addr, &100u32); // 1%
+    assert_eq!(client.calc_fee(&10_000i128), 100);
+}


### PR DESCRIPTION
Implement a fund that collects fees to be used as a backstop in case of a contract exploit or liquidation failure.

- deposit_fee(): any address (protocol) deposits collected fees
- withdraw(): admin draws from reserve to cover shortfalls
- set_fee_bps(): admin updates the fee rate (basis points)
- calc_fee(): helper to compute fee for a given principal
- Tracks total deposited and total withdrawn for auditability

Closes #198