### PR TITLE
feat: add Token Vesting contract

### DIFF
--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "soromint-vesting"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -1,0 +1,251 @@
+//! # SoroMint Token Vesting Contract
+//!
+//! Locks team/advisor tokens and releases them either:
+//! - **Linearly** – proportional to elapsed time between `start` and `end`.
+//! - **Milestone-based** – admin unlocks discrete tranches by calling
+//!   `release_milestone`.
+//!
+//! ## Linear vesting
+//! ```
+//! vested = total_amount * (now - start) / (end - start)
+//! claimable = vested - already_claimed
+//! ```
+//!
+//! ## Milestone vesting
+//! Admin pre-defines N milestones each with an `amount`. Calling
+//! `release_milestone(id)` marks it as released; the beneficiary then calls
+//! `claim` to pull the unlocked tokens.
+
+#![no_std]
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VestingKind {
+    Linear,
+    Milestone,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Milestone {
+    pub amount: i128,
+    pub released: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Token,
+    Beneficiary,
+    Kind,
+    TotalAmount,
+    Start,
+    End,
+    Claimed,
+    Milestones,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct Vesting;
+
+#[contractimpl]
+impl Vesting {
+    /// Initialize a **linear** vesting schedule.
+    pub fn init_linear(
+        e: Env,
+        admin: Address,
+        token: Address,
+        beneficiary: Address,
+        total_amount: i128,
+        start: u64,
+        end: u64,
+    ) {
+        Self::assert_not_init(&e);
+        if end <= start {
+            panic!("end <= start");
+        }
+        admin.require_auth();
+        // Deposit tokens into the contract
+        token::Client::new(&e, &token).transfer(
+            &admin,
+            &e.current_contract_address(),
+            &total_amount,
+        );
+        e.storage().instance().set(&DataKey::Admin, &admin);
+        e.storage().instance().set(&DataKey::Token, &token);
+        e.storage()
+            .instance()
+            .set(&DataKey::Beneficiary, &beneficiary);
+        e.storage()
+            .instance()
+            .set(&DataKey::Kind, &VestingKind::Linear);
+        e.storage()
+            .instance()
+            .set(&DataKey::TotalAmount, &total_amount);
+        e.storage().instance().set(&DataKey::Start, &start);
+        e.storage().instance().set(&DataKey::End, &end);
+        e.storage().instance().set(&DataKey::Claimed, &0i128);
+    }
+
+    /// Initialize a **milestone** vesting schedule.
+    pub fn init_milestone(
+        e: Env,
+        admin: Address,
+        token: Address,
+        beneficiary: Address,
+        milestones: Vec<i128>,
+    ) {
+        Self::assert_not_init(&e);
+        admin.require_auth();
+
+        let mut total: i128 = 0;
+        let mut ms: Vec<Milestone> = Vec::new(&e);
+        for amt in milestones.iter() {
+            total += amt;
+            ms.push_back(Milestone { amount: amt, released: false });
+        }
+
+        token::Client::new(&e, &token).transfer(&admin, &e.current_contract_address(), &total);
+
+        e.storage().instance().set(&DataKey::Admin, &admin);
+        e.storage().instance().set(&DataKey::Token, &token);
+        e.storage()
+            .instance()
+            .set(&DataKey::Beneficiary, &beneficiary);
+        e.storage()
+            .instance()
+            .set(&DataKey::Kind, &VestingKind::Milestone);
+        e.storage().instance().set(&DataKey::TotalAmount, &total);
+        e.storage().instance().set(&DataKey::Claimed, &0i128);
+        e.storage().persistent().set(&DataKey::Milestones, &ms);
+    }
+
+    /// Admin releases a milestone by index (milestone vesting only).
+    pub fn release_milestone(e: Env, index: u32) {
+        Self::require_admin(&e);
+        let kind: VestingKind = e.storage().instance().get(&DataKey::Kind).unwrap();
+        if kind != VestingKind::Milestone {
+            panic!("not milestone vesting");
+        }
+        let mut ms: Vec<Milestone> = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Milestones)
+            .unwrap();
+        let mut m = ms.get(index).expect("invalid milestone index");
+        if m.released {
+            panic!("already released");
+        }
+        m.released = true;
+        ms.set(index, m.clone());
+        e.storage().persistent().set(&DataKey::Milestones, &ms);
+        e.events()
+            .publish((symbol_short!("ms_rel"),), (index, m.amount));
+    }
+
+    /// Beneficiary claims all currently vested/released tokens.
+    pub fn claim(e: Env) -> i128 {
+        let beneficiary: Address = e.storage().instance().get(&DataKey::Beneficiary).unwrap();
+        beneficiary.require_auth();
+
+        let claimable = Self::claimable_amount(&e);
+        if claimable == 0 {
+            panic!("nothing to claim");
+        }
+
+        let claimed: i128 = e.storage().instance().get(&DataKey::Claimed).unwrap();
+        e.storage()
+            .instance()
+            .set(&DataKey::Claimed, &(claimed + claimable));
+
+        let tok: Address = e.storage().instance().get(&DataKey::Token).unwrap();
+        token::Client::new(&e, &tok).transfer(
+            &e.current_contract_address(),
+            &beneficiary,
+            &claimable,
+        );
+
+        e.events()
+            .publish((symbol_short!("claimed"),), (beneficiary, claimable));
+        claimable
+    }
+
+    /// Returns how many tokens can be claimed right now.
+    pub fn claimable(e: Env) -> i128 {
+        Self::claimable_amount(&e)
+    }
+
+    pub fn get_claimed(e: Env) -> i128 {
+        e.storage().instance().get(&DataKey::Claimed).unwrap_or(0)
+    }
+
+    pub fn version(_e: Env) -> String {
+        String::from_str(&_e, "1.0.0")
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn claimable_amount(e: &Env) -> i128 {
+        let kind: VestingKind = e.storage().instance().get(&DataKey::Kind).unwrap();
+        let claimed: i128 = e.storage().instance().get(&DataKey::Claimed).unwrap();
+
+        match kind {
+            VestingKind::Linear => {
+                let total: i128 = e.storage().instance().get(&DataKey::TotalAmount).unwrap();
+                let start: u64 = e.storage().instance().get(&DataKey::Start).unwrap();
+                let end: u64 = e.storage().instance().get(&DataKey::End).unwrap();
+                let now = e.ledger().timestamp();
+                if now <= start {
+                    return 0;
+                }
+                let elapsed = (now.min(end) - start) as i128;
+                let duration = (end - start) as i128;
+                let vested = total * elapsed / duration;
+                (vested - claimed).max(0)
+            }
+            VestingKind::Milestone => {
+                let ms: Vec<Milestone> = e
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Milestones)
+                    .unwrap();
+                let mut unlocked: i128 = 0;
+                for m in ms.iter() {
+                    if m.released {
+                        unlocked += m.amount;
+                    }
+                }
+                (unlocked - claimed).max(0)
+            }
+        }
+    }
+
+    fn assert_not_init(e: &Env) {
+        if e.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+    }
+
+    fn require_admin(e: &Env) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+    }
+}

--- a/contracts/vesting/src/test.rs
+++ b/contracts/vesting/src/test.rs
@@ -1,0 +1,83 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env,
+};
+
+fn setup_token(e: &Env, admin: &Address, amount: i128) -> Address {
+    let token_id = e.register_stellar_asset_contract_v2(admin.clone());
+    StellarAssetClient::new(e, &token_id.address()).mint(admin, &amount);
+    token_id.address()
+}
+
+#[test]
+fn test_linear_vesting() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.ledger().set_timestamp(1000);
+
+    let admin = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let token_addr = setup_token(&e, &admin, 1_000);
+    let token = TokenClient::new(&e, &token_addr);
+
+    let contract_id = e.register(Vesting, ());
+    let client = VestingClient::new(&e, &contract_id);
+
+    // start=1000, end=2000, total=1000
+    client.init_linear(&admin, &token_addr, &beneficiary, &1_000i128, &1000u64, &2000u64);
+
+    // At start: nothing vested
+    assert_eq!(client.claimable(), 0);
+
+    // At midpoint: 500 vested
+    e.ledger().set_timestamp(1500);
+    assert_eq!(client.claimable(), 500);
+
+    // Claim 500
+    let claimed = client.claim();
+    assert_eq!(claimed, 500);
+    assert_eq!(token.balance(&beneficiary), 500);
+
+    // At end: remaining 500 vested
+    e.ledger().set_timestamp(2000);
+    assert_eq!(client.claimable(), 500);
+    client.claim();
+    assert_eq!(token.balance(&beneficiary), 1000);
+}
+
+#[test]
+fn test_milestone_vesting() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let token_addr = setup_token(&e, &admin, 900);
+    let token = TokenClient::new(&e, &token_addr);
+
+    let contract_id = e.register(Vesting, ());
+    let client = VestingClient::new(&e, &contract_id);
+
+    let milestones = vec![&e, 300i128, 300i128, 300i128];
+    client.init_milestone(&admin, &token_addr, &beneficiary, &milestones);
+
+    // Nothing released yet
+    assert_eq!(client.claimable(), 0);
+
+    // Release milestone 0
+    client.release_milestone(&0u32);
+    assert_eq!(client.claimable(), 300);
+    client.claim();
+    assert_eq!(token.balance(&beneficiary), 300);
+
+    // Release milestones 1 and 2
+    client.release_milestone(&1u32);
+    client.release_milestone(&2u32);
+    assert_eq!(client.claimable(), 600);
+    client.claim();
+    assert_eq!(token.balance(&beneficiary), 900);
+}


### PR DESCRIPTION
Create a contract where team/advisor tokens are locked and released linearly or based on milestones over a period of time.

- init_linear(): locks tokens, releases proportionally over start→end
- init_milestone(): locks tokens, admin releases discrete tranches
- release_milestone(): admin marks a milestone as unlocked
- claim(): beneficiary pulls all currently vested/released tokens
- claimable(): view function returning claimable amount at current time

Closes #180