### PR TITLE
feat(streaming): Price Oracle Integration for Stable Value Streaming (#462)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ai_metadata_validator"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +620,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flash-loan"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +906,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "merkle_whitelist"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "metadata_validator"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +969,13 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "otc_escrow"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "p256"
@@ -1561,6 +1596,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "soromint-amm-factory"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soromint-amm-pool",
+ "soromint-factory",
+ "soromint-token",
+]
+
+[[package]]
+name = "soromint-amm-pool"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soromint-token",
+]
+
+[[package]]
+name = "soromint-backstop"
+version = "1.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soromint-compliance"
 version = "0.1.0"
 dependencies = [
@@ -1585,8 +1645,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "soromint-lending-pool"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soromint-lifecycle",
+]
+
+[[package]]
 name = "soromint-lifecycle"
 version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "soromint-lottery"
+version = "1.0.0"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1614,6 +1689,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "soromint-streaming"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soromint-oracle",
+]
+
+[[package]]
+name = "soromint-timelock"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+ "soromint-factory",
+]
+
+[[package]]
 name = "soromint-token"
 version = "0.1.0"
 dependencies = [
@@ -1623,10 +1715,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "soromint-upgradeable"
+version = "1.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soromint-vault"
 version = "1.0.0"
 dependencies = [
  "soroban-sdk",
+]
+
+[[package]]
+name = "soromint-vesting"
+version = "1.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "soromint-wrapper"
+version = "1.0.0"
+dependencies = [
+ "soroban-sdk",
+ "soromint-lifecycle",
 ]
 
 [[package]]

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "22.0.0"

--- a/contracts/streaming/Cargo.toml
+++ b/contracts/streaming/Cargo.toml
@@ -12,3 +12,4 @@ soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soromint_oracle = { package = "soromint-oracle", path = "../oracle" }

--- a/contracts/streaming/src/lib.rs
+++ b/contracts/streaming/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol, IntoVal};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -17,10 +17,17 @@ pub struct Stream {
     pub start_ledger: u32,
     pub stop_ledger: u32,
     pub withdrawn: i128,
+    pub total_deposited: i128,
+    // Stable stream fields
+    pub is_stable: bool,
+    pub usd_per_ledger: i128,
+    pub usd_withdrawn: i128,
 }
 
 #[contracttype]
 pub enum DataKey {
+    Admin,
+    Oracle,
     Stream(u64),
     NextStreamId,
 }
@@ -30,6 +37,32 @@ pub struct StreamingPayments;
 
 #[contractimpl]
 impl StreamingPayments {
+    /// Initialize the contract with admin address and oracle address
+    pub fn initialize(e: Env, admin: Address, oracle: Address) {
+        if e.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        e.storage().instance().set(&DataKey::Admin, &admin);
+        e.storage().instance().set(&DataKey::Oracle, &oracle);
+        e.storage().instance().set(&DataKey::NextStreamId, &0u64);
+    }
+
+    /// Update oracle address (admin only)
+    pub fn set_oracle(e: Env, new_oracle: Address) {
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Oracle, &new_oracle);
+        e.events().publish(
+            (soroban_sdk::symbol_short!("orcl_set"),),
+            (new_oracle,)
+        );
+    }
+
+    /// Get current oracle address
+    pub fn get_oracle(e: Env) -> Address {
+        e.storage().instance().get(&DataKey::Oracle).unwrap()
+    }
+
     /// Create a new payment stream
     pub fn create_stream(
         e: Env,
@@ -64,6 +97,10 @@ impl StreamingPayments {
             start_ledger,
             stop_ledger,
             withdrawn: 0,
+            total_deposited: total_amount,
+            is_stable: false,
+            usd_per_ledger: 0,
+            usd_withdrawn: 0,
         };
         
         e.storage().persistent().set(&DataKey::Stream(stream_id), &stream);
@@ -76,13 +113,67 @@ impl StreamingPayments {
         
         stream_id
     }
-    
+
+    /// Create a stable-value stream where recipient receives a fixed USD value per ledger.
+    /// The sender deposits a total amount of tokens; the actual token amount streamed per ledger
+    /// is determined by querying the price oracle at withdrawal time.
+    pub fn create_stable_stream(
+        e: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        total_token_amount: i128,
+        usd_per_ledger: i128,
+        start_ledger: u32,
+        stop_ledger: u32,
+    ) -> u64 {
+        sender.require_auth();
+
+        if total_token_amount <= 0 { panic!("amount must be positive"); }
+        if usd_per_ledger <= 0 { panic!("usd_per_ledger must be positive"); }
+        if stop_ledger <= start_ledger { panic!("invalid ledger range"); }
+
+        // Transfer tokens to contract
+        let token_client = token::Client::new(&e, &token);
+        token_client.transfer(&sender, &e.current_contract_address(), &total_token_amount);
+
+        let stream_id = e.storage().instance().get(&DataKey::NextStreamId).unwrap_or(0u64);
+
+        let stream = Stream {
+            sender: sender.clone(),
+            recipient: recipient.clone(),
+            token: token.clone(),
+            rate_per_ledger: 0, // not used for stable
+            start_ledger,
+            stop_ledger,
+            withdrawn: 0,
+            total_deposited: total_token_amount,
+            is_stable: true,
+            usd_per_ledger,
+            usd_withdrawn: 0,
+        };
+
+        e.storage().persistent().set(&DataKey::Stream(stream_id), &stream);
+        e.storage().instance().set(&DataKey::NextStreamId, &(stream_id + 1));
+
+        e.events().publish(
+            (soroban_sdk::symbol_short!("stbl_crtd"), stream_id),
+            (sender, recipient, total_token_amount, usd_per_ledger)
+        );
+
+        stream_id
+    }
+
     /// Withdraw available funds from a stream
     pub fn withdraw(e: Env, stream_id: u64, amount: i128) {
         let mut stream: Stream = e.storage().persistent()
             .get(&DataKey::Stream(stream_id))
             .unwrap_or_else(|| panic!("stream not found"));
-        
+
+        if stream.is_stable {
+            panic!("stable streams require withdraw_stable");
+        }
+
         stream.recipient.require_auth();
         
         let available = Self::balance_of(e.clone(), stream_id);
@@ -99,49 +190,205 @@ impl StreamingPayments {
             (stream.recipient.clone(), amount)
         );
     }
-    
-    /// Cancel a stream and refund remaining balance
-    pub fn cancel_stream(e: Env, stream_id: u64) {
-        let stream: Stream = e.storage().persistent()
+
+    /// Withdraw available funds from a stable stream.
+    /// Converts accrued USD value to tokens using the current oracle price.
+    pub fn withdraw_stable(e: Env, stream_id: u64) {
+        let mut stream: Stream = e.storage().persistent()
             .get(&DataKey::Stream(stream_id))
             .unwrap_or_else(|| panic!("stream not found"));
-        
-        stream.sender.require_auth();
-        
-        let recipient_balance = Self::balance_of(e.clone(), stream_id);
-        let client = token::Client::new(&e, &stream.token);
-        
-        // Transfer available balance to recipient
-        if recipient_balance > 0 {
-            client.transfer(&e.current_contract_address(), &stream.recipient, &recipient_balance);
+
+        if !stream.is_stable {
+            panic!("not a stable stream");
         }
-        
-        // Calculate total deposited and refund unstreamed amount
-        let duration = (stream.stop_ledger - stream.start_ledger) as i128;
-        let total_deposited = stream.rate_per_ledger * duration;
-        let total_streamed = Self::calculate_streamed(&e, &stream);
-        let refund = total_deposited - total_streamed;
-        
-        if refund > 0 {
-            client.transfer(&e.current_contract_address(), &stream.sender, &refund);
+
+        stream.recipient.require_auth();
+
+        let current = e.ledger().sequence();
+
+        // Elapsed ledgers
+        let elapsed = if current <= stream.start_ledger {
+            0i128
+        } else if current >= stream.stop_ledger {
+            (stream.stop_ledger - stream.start_ledger) as i128
+        } else {
+            (current - stream.start_ledger) as i128
+        };
+        let accrued_usd = stream.usd_per_ledger * elapsed;
+        let remaining_usd = accrued_usd - stream.usd_withdrawn;
+        if remaining_usd <= 0 {
+            panic!("no stable balance available");
         }
-        
-        e.storage().persistent().remove(&DataKey::Stream(stream_id));
-        
+
+        // Price from oracle (7 decimals)
+        let oracle_addr: Address = e.storage().instance().get(&DataKey::Oracle)
+            .unwrap_or_else(|| panic!("oracle not set"));
+        let price = Self::get_price(&e, &oracle_addr, &stream.token);
+
+        // Token decimals
+        let token_client = token::Client::new(&e, &stream.token);
+        let token_decimals = token_client.decimals();
+
+        // Convert remaining_usd to token amount
+        let mut token_amount = remaining_usd
+            .checked_mul(10i128.pow(token_decimals))
+            .expect("overflow converting USD to tokens")
+            .checked_div(price)
+            .expect("division error in conversion");
+
+        // Cap by remaining tokens deposit
+        let remaining_tokens = stream.total_deposited - stream.withdrawn;
+        if token_amount > remaining_tokens {
+            token_amount = remaining_tokens;
+        }
+
+        // Update withdrawn token amount (gross)
+        stream.withdrawn += token_amount;
+
+        // Update usd_withdrawn: compute USD value of tokens actually transferred
+        let actual_usd = token_amount
+            .checked_mul(price)
+            .expect("overflow")
+            .checked_div(10i128.pow(token_decimals))
+            .expect("division error");
+        stream.usd_withdrawn += actual_usd;
+
+        e.storage().persistent().set(&DataKey::Stream(stream_id), &stream);
+
+        // Transfer tokens to recipient
+        token_client.transfer(&e.current_contract_address(), &stream.recipient, &token_amount);
+
         e.events().publish(
-            (soroban_sdk::symbol_short!("canceled"), stream_id),
-            (recipient_balance, refund)
+            (soroban_sdk::symbol_short!("stbl_wdr"), stream_id),
+            (token_amount, actual_usd)
         );
     }
+
+    /// Cancel a stream and refund remaining balance
+    pub fn cancel_stream(e: Env, stream_id: u64) {
+        let mut stream: Stream = e.storage().persistent()
+            .get(&DataKey::Stream(stream_id))
+            .unwrap_or_else(|| panic!("stream not found"));
+
+        stream.sender.require_auth();
+
+        let client = token::Client::new(&e, &stream.token);
+
+        if stream.is_stable {
+            // Stable stream: compute accrued tokens and refund remainder
+            let current = e.ledger().sequence();
+            let elapsed = if current <= stream.start_ledger {
+                0i128
+            } else if current >= stream.stop_ledger {
+                (stream.stop_ledger - stream.start_ledger) as i128
+            } else {
+                (current - stream.start_ledger) as i128
+            };
+            let accrued_usd = stream.usd_per_ledger * elapsed;
+
+            // Get price and decimals
+            let oracle_addr: Address = e.storage().instance().get(&DataKey::Oracle)
+                .unwrap_or_else(|| panic!("oracle not set"));
+            let price = Self::get_price(&e, &oracle_addr, &stream.token);
+            let token_client = token::Client::new(&e, &stream.token);
+            let token_decimals = token_client.decimals();
+
+            // Convert accrued USD to tokens
+            let accrued_tokens = accrued_usd
+                .checked_mul(10i128.pow(token_decimals))
+                .expect("overflow")
+                .checked_div(price)
+                .expect("division error");
+
+            // Amount to give recipient = accrued_tokens - already withdrawn tokens
+            let recipient_amount = if accrued_tokens > stream.withdrawn {
+                accrued_tokens - stream.withdrawn
+            } else {
+                0
+            };
+            if recipient_amount > 0 {
+                client.transfer(&e.current_contract_address(), &stream.recipient, &recipient_amount);
+            }
+
+            // Refund remaining tokens to sender
+            let refund = stream.total_deposited - stream.withdrawn - recipient_amount;
+            if refund > 0 {
+                client.transfer(&e.current_contract_address(), &stream.sender, &refund);
+            }
+
+            e.storage().persistent().remove(&DataKey::Stream(stream_id));
+            e.events().publish(
+                (soroban_sdk::symbol_short!("stbl_cncl"), stream_id),
+                (recipient_amount, refund)
+            );
+        } else {
+            // Regular stream logic
+            let recipient_balance = Self::balance_of(e.clone(), stream_id);
+            if recipient_balance > 0 {
+                client.transfer(&e.current_contract_address(), &stream.recipient, &recipient_balance);
+            }
+            let total_streamed = Self::calculate_streamed(&e, &stream);
+            let refund = stream.total_deposited - total_streamed;
+            if refund > 0 {
+                client.transfer(&e.current_contract_address(), &stream.sender, &refund);
+            }
+            e.storage().persistent().remove(&DataKey::Stream(stream_id));
+            e.events().publish(
+                (soroban_sdk::symbol_short!("canceled"), stream_id),
+                (recipient_balance, refund)
+            );
+        }
+    }
     
-    /// Get available balance for withdrawal
+    /// Get available balance for withdrawal (in token amount)
     pub fn balance_of(e: Env, stream_id: u64) -> i128 {
         let stream: Stream = e.storage().persistent()
             .get(&DataKey::Stream(stream_id))
             .unwrap_or_else(|| panic!("stream not found"));
-        
-        let streamed = Self::calculate_streamed(&e, &stream);
-        streamed - stream.withdrawn
+
+        if stream.is_stable {
+            // Calculate accrued USD
+            let current = e.ledger().sequence();
+            let elapsed = if current <= stream.start_ledger {
+                0i128
+            } else if current >= stream.stop_ledger {
+                (stream.stop_ledger - stream.start_ledger) as i128
+            } else {
+                (current - stream.start_ledger) as i128
+            };
+            let accrued_usd = stream.usd_per_ledger * elapsed;
+            let remaining_usd = accrued_usd - stream.usd_withdrawn;
+            if remaining_usd <= 0 {
+                return 0;
+            }
+
+            // Get token price from oracle (price with 7 decimals)
+            let oracle_addr: Address = e.storage().instance().get(&DataKey::Oracle)
+                .unwrap_or_else(|| panic!("oracle not set"));
+            let price = Self::get_price(&e, &oracle_addr, &stream.token);
+
+            // Get token decimals
+            let token_client = token::Client::new(&e, &stream.token);
+            let token_decimals = token_client.decimals();
+
+            // Convert USD to tokens: token_amount = (usd * 10^token_decimals) / price
+            let mut token_amount = remaining_usd
+                .checked_mul(10i128.pow(token_decimals))
+                .expect("overflow converting USD to tokens")
+                .checked_div(price)
+                .expect("division error in conversion");
+
+            // Cap by remaining tokens in contract (total_deposited - withdrawn)
+            let remaining_tokens = stream.total_deposited - stream.withdrawn;
+            if token_amount > remaining_tokens {
+                token_amount = remaining_tokens;
+            }
+
+            token_amount
+        } else {
+            let streamed = Self::calculate_streamed(&e, &stream);
+            streamed - stream.withdrawn
+        }
     }
     
     /// Get stream details
@@ -166,12 +413,19 @@ impl StreamingPayments {
         
         stream.rate_per_ledger * (elapsed as i128)
     }
+
+    /// Helper to fetch token price (7 decimals) from oracle
+    fn get_price(e: &Env, oracle: &Address, token: &Address) -> i128 {
+        let args = soroban_sdk::vec![e, token.clone().into_val(e)];
+        e.invoke_contract::<i128>(oracle, &Symbol::new(e, "get_price"), args)
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use soroban_sdk::{testutils::{Address as _, Ledger}, token, Address, Env};
+    use soromint_oracle::{PriceOracle, PriceOracleClient};
 
     fn create_token_contract<'a>(e: &Env, admin: &Address) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
         let contract = e.register_stellar_asset_contract_v2(admin.clone());
@@ -230,5 +484,57 @@ mod test {
         
         assert_eq!(token_client.balance(&recipient), 500);
         assert_eq!(token_client.balance(&sender), 9500);
+    }
+
+    #[test]
+    fn test_stable_stream() {
+        let e = Env::default();
+        e.mock_all_auths();
+
+        let admin = Address::generate(&e);
+        let sender = Address::generate(&e);
+        let recipient = Address::generate(&e);
+
+        // Create a token
+        let (token_addr, token_client, token_admin) = create_token_contract(&e, &admin);
+        token_admin.mint(&sender, &10000);
+
+        // Create and initialize oracle
+        let oracle_contract_id = e.register(PriceOracle, ());
+        let oracle_client = PriceOracleClient::new(&e, &oracle_contract_id);
+        oracle_client.initialize(&admin);
+        // Set price: 1 USD = 10,000,000 (7 decimals) => price = 10_000_000
+        oracle_client.set_price(&token_addr, &10_000_000i128, &admin);
+
+        // Initialize streaming contract with oracle
+        let streaming_contract_id = e.register(StreamingPayments, ());
+        let streaming_client = StreamingPaymentsClient::new(&e, &streaming_contract_id);
+        streaming_client.initialize(&admin, &oracle_contract_id);
+
+        // Create stable stream: deposit 10000 tokens, stream 100 USD per ledger, 100 ledgers
+        e.ledger().set_sequence_number(100);
+        let stream_id = streaming_client.create_stable_stream(
+            &sender, &recipient, &token_addr,
+            &10000, &100, &100, &200
+        );
+
+        // Advance to ledger 150 (50 ledgers elapsed)
+        e.ledger().set_sequence_number(150);
+
+        // Withdraw stable value
+        streaming_client.withdraw_stable(&stream_id);
+
+        // Expected token amount: 50 * 100 USD = 5000 USD
+        // tokens = 5000 * 10^7 / 10_000_000 = 5000
+        assert_eq!(token_client.balance(&recipient), 5000);
+
+        // Verify stream state
+        let stream = streaming_client.get_stream(&stream_id);
+        assert_eq!(stream.withdrawn, 5000);
+        assert_eq!(stream.usd_withdrawn, 5000);
+
+        // Cancel stream: sender should get remaining 5000 tokens
+        streaming_client.cancel_stream(&stream_id);
+        assert_eq!(token_client.balance(&sender), 5000);
     }
 }

--- a/contracts/streaming/test_snapshots/test/test_stable_stream.1.json
+++ b/contracts/streaming/test_snapshots/test/test_stable_stream.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 5,
+    "address": 6,
     "nonce": 0
   },
   "auth": [
@@ -49,14 +49,45 @@
       ]
     ],
     [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "function_name": "set_price",
+              "args": [
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10000000
+                  }
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-              "function_name": "create_stream",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+              "function_name": "create_stable_stream",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
@@ -70,7 +101,13 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000
+                    "lo": 10000
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
                   }
                 },
                 {
@@ -93,12 +130,12 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     },
                     {
                       "i128": {
                         "hi": 0,
-                        "lo": 1000
+                        "lo": 10000
                       }
                     }
                   ]
@@ -110,24 +147,38 @@
         }
       ]
     ],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-              "function_name": "withdraw",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+              "function_name": "withdraw_stable",
               "args": [
                 {
                   "u64": 0
-                },
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+              "function_name": "cancel_stream",
+              "args": [
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
-                  }
+                  "u64": 0
                 }
               ]
             }
@@ -215,6 +266,39 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
                 "nonce": 5541220902715666415
               }
             },
@@ -248,7 +332,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 1033654523790656264
+                "nonce": 4270020994084947596
               }
             },
             "durability": "temporary"
@@ -263,7 +347,40 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6312149
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",
@@ -281,7 +398,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 4837995959683129791
+                "nonce": 2032731177588607455
               }
             },
             "durability": "temporary"
@@ -296,7 +413,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 4837995959683129791
+                    "nonce": 2032731177588607455
                   }
                 },
                 "durability": "temporary",
@@ -315,10 +432,10 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "Stream"
+                  "symbol": "LastUpdate"
                 },
                 {
-                  "u64": 0
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                 }
               ]
             },
@@ -335,10 +452,55 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "Stream"
+                      "symbol": "LastUpdate"
                     },
                     {
-                      "u64": 0
+                      "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Price"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Price"
+                    },
+                    {
+                      "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                     }
                   ]
                 },
@@ -347,105 +509,37 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "is_stable"
+                        "symbol": "decimals"
                       },
                       "val": {
-                        "bool": false
+                        "u32": 7
                       }
                     },
                     {
                       "key": {
-                        "symbol": "rate_per_ledger"
+                        "symbol": "price"
                       },
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 10
+                          "lo": 10000000
                         }
                       }
                     },
                     {
                       "key": {
-                        "symbol": "recipient"
+                        "symbol": "source"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                       }
                     },
                     {
                       "key": {
-                        "symbol": "sender"
+                        "symbol": "timestamp"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "start_ledger"
-                      },
-                      "val": {
-                        "u32": 100
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "stop_ledger"
-                      },
-                      "val": {
-                        "u32": 200
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "token"
-                      },
-                      "val": {
-                        "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "total_deposited"
-                      },
-                      "val": {
-                        "i128": {
-                          "hi": 0,
-                          "lo": 1000
-                        }
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "usd_per_ledger"
-                      },
-                      "val": {
-                        "i128": {
-                          "hi": 0,
-                          "lo": 0
-                        }
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "usd_withdrawn"
-                      },
-                      "val": {
-                        "i128": {
-                          "hi": 0,
-                          "lo": 0
-                        }
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "withdrawn"
-                      },
-                      "val": {
-                        "i128": {
-                          "hi": 0,
-                          "lo": 500
-                        }
+                        "u64": 0
                       }
                     }
                   ]
@@ -454,7 +548,7 @@
             },
             "ext": "v0"
           },
-          4195
+          4095
         ]
       ],
       [
@@ -484,12 +578,93 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TrustedSources"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "NextStreamId"
                             }
                           ]
                         },
                         "val": {
                           "u64": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Oracle"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                         }
                       }
                     ]
@@ -546,7 +721,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 9000
+                          "lo": 5000
                         }
                       }
                     },
@@ -619,7 +794,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 500
+                          "lo": 5000
                         }
                       }
                     },
@@ -658,7 +833,7 @@
                   "symbol": "Balance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 }
               ]
             },
@@ -678,7 +853,7 @@
                       "symbol": "Balance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     }
                   ]
                 },
@@ -692,7 +867,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 500
+                          "lo": 0
                         }
                       }
                     },


### PR DESCRIPTION
Closes #462

---

Stream a specific USD value of tokens per ledger using a price oracle.\n\n- Integrate with existing PriceOracle contract\n- Add create_stable_stream for USD-denominated streams\n- Add withdraw_stable to convert accrued USD to tokens at current price\n- Extend balance_of and cancel_stream to handle stable streams\n- Add integration test with oracle