### PR TITLE
feat: add exponential backoff retry for Stellar/EVM RPC calls

### DIFF
--- a/server/services/bridge-relayer.js
+++ b/server/services/bridge-relayer.js
@@ -7,6 +7,7 @@
 const { logger } = require("../utils/logger");
 const { getEnv } = require("../config/env-config");
 const { SOURCE_CHAINS } = require("../validators/bridge-validator");
+const { retryWithBackoff } = require("../utils/retry");
 
 /**
  * Event action classification
@@ -442,33 +443,35 @@ class BridgeRelayer {
   }
 
   /**
-   * Make EVM JSON-RPC call
+   * Make EVM JSON-RPC call with exponential backoff retry
    */
   async _evmRpcCall(method, params) {
-    const response = await fetch(this.config.evmRpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        method,
-        params,
-        id: Date.now(),
-      }),
-    });
+    return retryWithBackoff(async () => {
+      const response = await fetch(this.config.evmRpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method,
+          params,
+          id: Date.now(),
+        }),
+      });
 
-    if (!response.ok) {
-      throw new Error(`EVM RPC request failed with HTTP ${response.status}`);
-    }
+      if (!response.ok) {
+        throw new Error(`EVM RPC request failed with HTTP ${response.status}`);
+      }
 
-    const payload = await response.json();
+      const payload = await response.json();
 
-    if (payload.error) {
-      throw new Error(
-        payload.error.message || "Unknown EVM RPC error",
-      );
-    }
+      if (payload.error) {
+        throw new Error(
+          payload.error.message || "Unknown EVM RPC error",
+        );
+      }
 
-    return payload.result;
+      return payload.result;
+    }, { label: `EVM RPC [${method}]` });
   }
 
   /**

--- a/server/services/stellar-service.js
+++ b/server/services/stellar-service.js
@@ -12,6 +12,7 @@ const {
 } = require('@stellar/stellar-sdk');
 const { getEnv } = require('../config/env-config');
 const { logger } = require('../utils/logger');
+const { retryWithBackoff } = require('../utils/retry');
 
 /**
  * @title FailoverRpcServer
@@ -63,12 +64,14 @@ class FailoverRpcServer {
     let lastError;
 
     for (let i = 0; i < this.urls.length; i++) {
+      const url = this.urls[this.currentIndex];
+      const server = this.current;
       try {
-        return await fn(this.current);
+        return await retryWithBackoff(() => fn(server), { label: `Soroban RPC [${url}]` });
       } catch (error) {
         lastError = error;
-        logger.error('RPC call failed, attempting failover', {
-          url: this.urls[this.currentIndex],
+        logger.error('RPC endpoint exhausted retries, attempting failover', {
+          url,
           error: error.message
         });
         this.next();

--- a/server/tests/utils/retry.test.js
+++ b/server/tests/utils/retry.test.js
@@ -1,0 +1,76 @@
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn() },
+}));
+
+const { retryWithBackoff } = require('../../utils/retry');
+const { logger } = require('../../utils/logger');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('retryWithBackoff', () => {
+  test('resolves immediately on first success', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await retryWithBackoff(fn, { label: 'test' });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('retries on failure and succeeds on second attempt', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce('recovered');
+
+    // Use tiny delay so test doesn't take long
+    const result = await retryWithBackoff(fn, { maxRetries: 2, baseDelayMs: 1, label: 'test' });
+
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('test failed, retrying in 1ms'),
+      expect.objectContaining({ attempt: 1, maxRetries: 2 })
+    );
+  });
+
+  test('throws after exhausting all retries', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('permanent'));
+
+    await expect(
+      retryWithBackoff(fn, { maxRetries: 3, baseDelayMs: 1, label: 'test' })
+    ).rejects.toThrow('permanent');
+
+    expect(fn).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('test failed permanently after 4 attempts'),
+      expect.objectContaining({ error: 'permanent' })
+    );
+  });
+
+  test('uses exponential backoff delays', async () => {
+    const delays = [];
+    const spy = jest.spyOn(global, 'setTimeout').mockImplementation((cb, ms) => {
+      delays.push(ms);
+      return setImmediate(cb); // execute immediately without real delay
+    });
+
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('e1'))
+      .mockRejectedValueOnce(new Error('e2'))
+      .mockResolvedValueOnce('done');
+
+    const result = await retryWithBackoff(fn, { maxRetries: 3, baseDelayMs: 1000, label: 'test' });
+
+    expect(result).toBe('done');
+    expect(delays).toEqual([1000, 2000]); // 1s then 2s
+    spy.mockRestore();
+  });
+
+  test('uses default options when none provided', async () => {
+    const fn = jest.fn().mockResolvedValue('default');
+    const result = await retryWithBackoff(fn);
+    expect(result).toBe('default');
+  });
+});

--- a/server/utils/retry.js
+++ b/server/utils/retry.js
@@ -1,0 +1,48 @@
+const { logger } = require('./logger');
+
+const DEFAULT_MAX_RETRIES = 4;
+const DEFAULT_BASE_DELAY_MS = 1000;
+
+/**
+ * Retries an async function with exponential backoff.
+ * Delays: 1s, 2s, 4s, 8s (by default).
+ *
+ * @param {Function} fn - Async function to execute.
+ * @param {Object} [options]
+ * @param {number} [options.maxRetries=4] - Maximum number of retry attempts.
+ * @param {number} [options.baseDelayMs=1000] - Base delay in ms (doubles each retry).
+ * @param {string} [options.label='RPC call'] - Label for log messages.
+ * @returns {Promise<any>} Result of fn on success.
+ * @throws {Error} Last error after all retries are exhausted.
+ */
+const retryWithBackoff = async (fn, { maxRetries = DEFAULT_MAX_RETRIES, baseDelayMs = DEFAULT_BASE_DELAY_MS, label = 'RPC call' } = {}) => {
+  let lastError;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === maxRetries) {
+        logger.error(`${label} failed permanently after ${maxRetries + 1} attempts`, {
+          error: error.message,
+        });
+        break;
+      }
+
+      const delay = baseDelayMs * Math.pow(2, attempt);
+      logger.warn(`${label} failed, retrying in ${delay}ms`, {
+        attempt: attempt + 1,
+        maxRetries,
+        error: error.message,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+};
+
+module.exports = { retryWithBackoff };


### PR DESCRIPTION
- Add server/utils/retry.js with retryWithBackoff() utility (max 4 retries, delays: 1s, 2s, 4s, 8s; logs warn per retry, error on permanent failure)
- Wrap FailoverRpcServer.execute() with per-endpoint retryWithBackoff so transient errors are retried before failing over to the next endpoint
- Wrap BridgeRelayer._evmRpcCall() with retryWithBackoff so transient EVM RPC errors are retried before propagating
- Add tests/utils/retry.test.js with 5 passing unit tests

Closes #514 