### PR TITLE
Feature/fuzz token factory

### DIFF
--- a/contracts/factory/src/test_factory.rs
+++ b/contracts/factory/src/test_factory.rs
@@ -311,3 +311,71 @@ proptest! {
         let _ = client.status();
     }
 }
+
+proptest! {
+    // Fuzz: create_token with randomized inputs (valid and invalid)
+    #[test]
+    fn prop_fuzz_create_token(salt_bytes in any::<[u8;32]>(), decimal in any::<u32>(), name_vec in prop::collection::vec('a'..'z', 0..40), symbol_vec in prop::collection::vec('A'..'Z', 0..10)) {
+        use std::panic::catch_unwind;
+
+        let (e, admin, client) = setup();
+        let wasm_hash = e.deployer().upload_contract_wasm(token::WASM);
+        client.initialize(&admin, &wasm_hash);
+
+        let salt = BytesN::from_array(&e, &salt_bytes);
+        let token_admin = Address::generate(&e);
+        let name_str: String = String::from_str(&e, &String::from_utf8(name_vec.clone().into_iter().map(|c| c as u8).collect()).unwrap_or_default());
+        let symbol_str: String = String::from_str(&e, &String::from_utf8(symbol_vec.clone().into_iter().map(|c| c as u8).collect()).unwrap_or_default());
+
+        // Attempt creation inside catch_unwind so we can assert registry state is not corrupted on panic
+        let res = catch_unwind(|| {
+            let _ = client.create_token(&salt, &token_admin, &decimal, &name_str, &symbol_str);
+        });
+
+        let tokens = client.get_tokens();
+        if res.is_err() {
+            // If the call panicked, the registry must remain empty
+            prop_assert_eq!(tokens.len(), 0);
+        } else {
+            // Successful deploy should have exactly one token registered and its metadata match
+            prop_assert_eq!(tokens.len(), 1);
+            let token_address = tokens.get(0).unwrap();
+            let token_client = token::Client::new(&e, &token_address);
+            prop_assert_eq!(token_client.decimals(), decimal);
+            prop_assert_eq!(token_client.name(), name_str);
+            prop_assert_eq!(token_client.symbol(), symbol_str);
+        }
+    }
+
+    // Fuzz: update_wasm_hash authorized vs unauthorized
+    #[test]
+    fn prop_fuzz_update_wasm_hash_auth(new_hash in any::<[u8;32]>()) {
+        use std::panic::catch_unwind;
+
+        // Authorized update (using mocked auths via setup)
+        let (e, admin, client) = setup();
+        let wasm_hash = e.deployer().upload_contract_wasm(token::WASM);
+        client.initialize(&admin, &wasm_hash);
+        let new_hash_bn = BytesN::from_array(&e, &new_hash);
+        client.update_wasm_hash(&new_hash_bn);
+        // verify updated
+        // There's no direct getter for WasmHash, but re-initializing should fail if already initialized; instead ensure create_token still uses wasm (smoke)
+        // Try creating a token to ensure contract still functional
+        let salt = BytesN::from_array(&e, &[7;32]);
+        let token_admin = Address::generate(&e);
+        let name = String::from_str(&e, "FuzzToken");
+        let symbol = String::from_str(&e, "FZ");
+        let _ = client.create_token(&salt, &token_admin, &8u32, &name, &symbol);
+
+        // Unauthorized update should panic when not providing auth
+        let e2 = Env::default();
+        let admin2 = Address::generate(&e2);
+        let factory_id = e2.register(TokenFactory, ());
+        let client2 = TokenFactoryClient::new(&e2, &factory_id);
+        client2.initialize(&admin2, &BytesN::from_array(&e2, &[0;32]));
+        let bad_res = catch_unwind(|| {
+            client2.update_wasm_hash(&BytesN::from_array(&e2, &new_hash));
+        });
+        prop_assert!(bad_res.is_err());
+    }
+}

--- a/server/models/SorobanEvent.js
+++ b/server/models/SorobanEvent.js
@@ -18,5 +18,10 @@ const SorobanEventSchema = new mongoose.Schema(
 SorobanEventSchema.index({ contractId: 1, ledger: -1 });
 SorobanEventSchema.index({ eventType: 1, ledgerClosedAt: -1 });
 SorobanEventSchema.index({ contractId: 1, eventType: 1, ledgerClosedAt: -1 });
+SorobanEventSchema.index({
+  contractId: 1,
+  inSuccessfulContractCall: 1,
+  ledgerClosedAt: -1,
+});
 
 module.exports = mongoose.model('SorobanEvent', SorobanEventSchema);

--- a/server/routes/soroban-event-routes.js
+++ b/server/routes/soroban-event-routes.js
@@ -22,6 +22,9 @@ const router = express.Router();
  * @param {integer} limit - Results per page (optional, default: 50)
  * @returns {object} 200 - Events with pagination metadata
  */
+const EVENT_LIST_PROJECTION =
+  'contractId eventType ledger ledgerClosedAt txHash inSuccessfulContractCall createdAt updatedAt';
+
 router.get('/events', authenticate, async (req, res) => {
   try {
     const {
@@ -44,6 +47,7 @@ router.get('/events', authenticate, async (req, res) => {
 
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const events = await SorobanEvent.find(query)
+      .select(EVENT_LIST_PROJECTION)
       .sort({ ledger: -1 })
       .skip(skip)
       .limit(parseInt(limit))
@@ -77,7 +81,24 @@ router.get('/events', authenticate, async (req, res) => {
  */
 router.get('/events/stats', authenticate, async (req, res) => {
   try {
+    const {
+      contractId,
+      eventType,
+      startLedger,
+      endLedger,
+    } = req.query;
+
+    const query = {};
+    if (contractId) query.contractId = contractId;
+    if (eventType) query.eventType = eventType;
+    if (startLedger || endLedger) {
+      query.ledger = {};
+      if (startLedger) query.ledger.$gte = parseInt(startLedger);
+      if (endLedger) query.ledger.$lte = parseInt(endLedger);
+    }
+
     const stats = await SorobanEvent.aggregate([
+      { $match: query },
       {
         $group: {
           _id: '$contractId',

--- a/server/tests/routes/soroban-event-routes.test.js
+++ b/server/tests/routes/soroban-event-routes.test.js
@@ -1,0 +1,61 @@
+jest.mock('../../middleware/auth', () => ({
+  authenticate: (req, res, next) => next(),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const express = require('express');
+const request = require('supertest');
+const SorobanEvent = require('../../models/SorobanEvent');
+const eventRoutes = require('../../routes/soroban-event-routes');
+
+describe('SorobanEvent routes', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses a narrow projection when fetching events', async () => {
+    const mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([]),
+    };
+
+    jest.spyOn(SorobanEvent, 'find').mockReturnValue(mockQuery);
+    jest.spyOn(SorobanEvent, 'countDocuments').mockResolvedValue(0);
+
+    const app = express();
+    app.use('/api', eventRoutes);
+
+    await request(app).get('/api/events').query({ contractId: 'contract-123' });
+
+    expect(SorobanEvent.find).toHaveBeenCalledWith({ contractId: 'contract-123' });
+    expect(mockQuery.select).toHaveBeenCalledWith(
+      expect.stringContaining('contractId')
+    );
+  });
+
+  it('applies match before grouping stats', async () => {
+    jest.spyOn(SorobanEvent, 'aggregate').mockResolvedValue([]);
+
+    const app = express();
+    app.use('/api', eventRoutes);
+
+    await request(app).get('/api/events/stats').query({ contractId: 'contract-123' });
+
+    expect(SorobanEvent.aggregate).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ $match: { contractId: 'contract-123' } }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
Adds randomized property-based tests to improve resilience of the Token Factory:
Adds fuzzing for [create_token](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that generates random salts, decimals, names and symbols, and asserts either successful deployment with matching token metadata or a panic without corrupting the factory registry.
Adds fuzzing for [update_wasm_hash](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) verifying authorized updates succeed and unauthorized attempts panic as expected.
Tests use [proptest](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [catch_unwind](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ensure state is preserved on failure.
File: [test_factory.rs](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Note: Local [cargo test](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) failed to compile due to unrelated duplicate-definition errors in [lib.rs](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). CI may show the same; recommend resolving those token crate compilation errors (duplicate definitions) so the fuzz tests can run end-to-end.

Closes #746 