### PR TITLE
feat: implement zk_metadata_verifier contract logic with comprehensive test snapshot coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "soromint-zk-metadata-verifier"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "soromint-zk-mint-gateway"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soromint-zk-metadata-verifier",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
     "contracts/vault",
     "contracts/vesting",
     "contracts/wrapper",
+    "contracts/zk_metadata_verifier",
+    "contracts/zk_mint_gateway",
 ]
 
 

--- a/contracts/zk_metadata_verifier/Cargo.toml
+++ b/contracts/zk_metadata_verifier/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "soromint-zk-metadata-verifier"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Groth16 (BLS12-381) on-chain verifier for decentralized AI metadata validation"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/zk_metadata_verifier/src/access.rs
+++ b/contracts/zk_metadata_verifier/src/access.rs
@@ -1,0 +1,119 @@
+//! Role-based access control.
+//!
+//! The root `Admin` implicitly holds every role, so a fresh deployment is
+//! usable before any delegation happens. Delegated roles are additive and
+//! narrow:
+//!
+//! * `PolicyAdmin` moves the safety goalposts (thresholds, blocklist root).
+//! * `CircuitAdmin` moves the *proof system* (verifying keys).
+//! * `Pauser` can stop the world but not restart it.
+//! * `Consumer` is held by lifecycle contracts, not humans.
+//!
+//! Splitting policy from circuits matters: a compromised policy key can only
+//! loosen thresholds within the constraints the circuit already enforces, while
+//! a compromised circuit key could install a verifying key that accepts
+//! anything. The circuit path is therefore additionally protected by a
+//! timelock (see [`crate::registry`]).
+
+use soroban_sdk::{Address, Env};
+
+use crate::errors::Error;
+use crate::storage;
+use crate::types::Role;
+
+/// Assert `caller` authorized this invocation and holds `role` (or is Admin).
+pub fn require_role(env: &Env, caller: &Address, role: Role) -> Result<(), Error> {
+    caller.require_auth();
+    if is_admin(env, caller)? || storage::has_role(env, role, caller) {
+        Ok(())
+    } else {
+        Err(Error::Unauthorized)
+    }
+}
+
+/// Assert `caller` authorized this invocation and is the root admin.
+pub fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    caller.require_auth();
+    if is_admin(env, caller)? {
+        Ok(())
+    } else {
+        Err(Error::Unauthorized)
+    }
+}
+
+/// Role check without an auth requirement, for read-only queries.
+pub fn check_role(env: &Env, who: &Address, role: Role) -> bool {
+    match is_admin(env, who) {
+        Ok(true) => true,
+        _ => storage::has_role(env, role, who),
+    }
+}
+
+pub fn is_admin(env: &Env, who: &Address) -> Result<bool, Error> {
+    let admin = storage::get_admin(env)?;
+    Ok(&admin == who)
+}
+
+/// Grant `role` to `who`. Admin-only.
+pub fn grant(env: &Env, caller: &Address, role: Role, who: &Address) -> Result<(), Error> {
+    require_admin(env, caller)?;
+    if role == Role::Admin {
+        // The root admin is a single address managed through the two-step
+        // transfer flow, not a set. Granting it as a plain role would create a
+        // second admin with no transfer ceremony behind it.
+        return Err(Error::InvalidRoleTarget);
+    }
+    storage::grant_role(env, role, who);
+    crate::events::role_granted(env, role, who, caller);
+    Ok(())
+}
+
+/// Revoke `role` from `who`. Admin-only.
+pub fn revoke(env: &Env, caller: &Address, role: Role, who: &Address) -> Result<(), Error> {
+    require_admin(env, caller)?;
+    if role == Role::Admin {
+        return Err(Error::InvalidRoleTarget);
+    }
+    storage::revoke_role(env, role, who);
+    crate::events::role_revoked(env, role, who, caller);
+    Ok(())
+}
+
+/// Step one of the admin handoff: the incumbent nominates a successor.
+///
+/// A direct `set_admin` is a foot-gun — one typo permanently bricks governance.
+/// The nominee must call [`accept_admin`] from their own key, which proves the
+/// address is both correct and controlled.
+pub fn transfer_admin(env: &Env, caller: &Address, new_admin: &Address) -> Result<(), Error> {
+    require_admin(env, caller)?;
+    if new_admin == caller {
+        return Err(Error::InvalidRoleTarget);
+    }
+    storage::set_pending_admin(env, new_admin);
+    crate::events::admin_transfer_started(env, caller, new_admin);
+    Ok(())
+}
+
+/// Step two: the nominee claims the role.
+pub fn accept_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    caller.require_auth();
+    let pending = storage::get_pending_admin(env).ok_or(Error::NoPendingTransfer)?;
+    if &pending != caller {
+        return Err(Error::NoPendingTransfer);
+    }
+    let previous = storage::get_admin(env)?;
+    storage::set_admin(env, caller);
+    storage::clear_pending_admin(env);
+    crate::events::admin_transfer_completed(env, &previous, caller);
+    Ok(())
+}
+
+/// Abort a pending handoff.
+pub fn cancel_admin_transfer(env: &Env, caller: &Address) -> Result<(), Error> {
+    require_admin(env, caller)?;
+    if storage::get_pending_admin(env).is_none() {
+        return Err(Error::NoPendingTransfer);
+    }
+    storage::clear_pending_admin(env);
+    Ok(())
+}

--- a/contracts/zk_metadata_verifier/src/attestation.rs
+++ b/contracts/zk_metadata_verifier/src/attestation.rs
@@ -1,0 +1,184 @@
+//! Nullifiers and attestation records.
+//!
+//! # Why a nullifier and not just "hash of the proof"
+//!
+//! Groth16 proofs are randomized: re-running the prover on identical inputs
+//! yields a different `(A, B, C)` every time. Keying replay protection on the
+//! proof bytes would therefore protect nothing — an attacker who obtains a
+//! witness can mint fresh proofs of the same statement forever.
+//!
+//! The nullifier is computed *inside the circuit* as
+//! `Poseidon(metadataCommitment, issuerHash, nonce)` and exposed as a public
+//! signal. Because the circuit constrains it, the prover cannot choose it
+//! freely; because it is deterministic in the witness, two proofs of the same
+//! statement collide on it. Spending it once closes the replay.
+//!
+//! # Why attestations are separate from nullifiers
+//!
+//! A nullifier answers "has this proof been used?". An attestation answers
+//! "what was approved, by which rules, and is it still good?". The mint
+//! lifecycle needs the second question answered days after the first, and needs
+//! it answered cheaply — re-verifying a pairing on every mint would make the
+//! design unusable.
+
+use soroban_sdk::{Address, Env, Symbol};
+
+use crate::errors::Error;
+use crate::events;
+use crate::storage;
+use crate::types::{Attestation, AttestationStatus, Config, Digest, MetadataSignals};
+
+/// Reject a nullifier that has already been spent.
+pub fn require_unspent(env: &Env, nullifier: &Digest) -> Result<(), Error> {
+    if storage::nullifier_spent_at(env, nullifier).is_some() {
+        return Err(Error::NullifierAlreadyUsed);
+    }
+    Ok(())
+}
+
+/// Mark a nullifier spent.
+///
+/// The TTL comes from [`Config::nullifier_ttl`], which policy validation forces
+/// to exceed the longest proof validity window. If that invariant were ever
+/// broken, an expired nullifier entry would silently re-enable replay of a
+/// proof that had not yet expired.
+pub fn spend(env: &Env, nullifier: &Digest, issuer: &Address, config: &Config) {
+    storage::spend_nullifier(env, nullifier, config.nullifier_ttl);
+    storage::with_stats(env, |s| {
+        s.nullifiers_spent = s.nullifiers_spent.saturating_add(1)
+    });
+    events::nullifier_spent(env, nullifier, issuer);
+}
+
+/// Build and persist the attestation for a freshly verified proof.
+pub fn issue(
+    env: &Env,
+    signals: &MetadataSignals,
+    issuer: &Address,
+    circuit_id: &Symbol,
+    policy_version: u32,
+    config: &Config,
+) -> Attestation {
+    let now = env.ledger().sequence();
+
+    // The attestation expires at whichever comes first: the proof's own claimed
+    // expiry, or the configured retention window. Honouring the proof's expiry
+    // matters — an issuer who proved "safe as of ledger N" has not proved
+    // anything about ledger N + 100_000.
+    let ttl_bound = now.saturating_add(config.attestation_ttl);
+    let expires_at = if signals.expiry_ledger < ttl_bound {
+        signals.expiry_ledger
+    } else {
+        ttl_bound
+    };
+
+    let attestation = Attestation {
+        metadata_commitment: signals.metadata_commitment.clone(),
+        issuer: issuer.clone(),
+        nullifier: signals.nullifier.clone(),
+        policy_version,
+        circuit_id: circuit_id.clone(),
+        risk_score: signals.risk_score,
+        verified_at: now,
+        expires_at,
+        consumed: false,
+        consumer: None,
+        consumed_at: None,
+    };
+
+    storage::set_attestation(env, &attestation, config.attestation_ttl);
+    storage::bump_issuer_count(env, issuer);
+    storage::with_stats(env, |s| {
+        s.attestations_issued = s.attestations_issued.saturating_add(1)
+    });
+    events::attestation_issued(
+        env,
+        &attestation.metadata_commitment,
+        issuer,
+        attestation.risk_score,
+        policy_version,
+        expires_at,
+    );
+
+    attestation
+}
+
+/// Fetch an attestation and assert it is currently redeemable.
+pub fn require_valid(env: &Env, commitment: &Digest) -> Result<Attestation, Error> {
+    let attestation = storage::get_attestation(env, commitment)?;
+    if attestation.consumed {
+        return Err(Error::AttestationAlreadyConsumed);
+    }
+    if env.ledger().sequence() > attestation.expires_at {
+        return Err(Error::AttestationExpired);
+    }
+    Ok(attestation)
+}
+
+/// Redeem an attestation on behalf of a lifecycle contract.
+///
+/// Single-use by construction: the `consumed` flag is set in the same
+/// transaction the caller reads it, so a token cannot be created twice off one
+/// safety proof.
+pub fn consume(
+    env: &Env,
+    consumer: &Address,
+    commitment: &Digest,
+    expected_issuer: &Address,
+) -> Result<Attestation, Error> {
+    let mut attestation = require_valid(env, commitment)?;
+
+    if &attestation.issuer != expected_issuer {
+        return Err(Error::IssuerBindingMismatch);
+    }
+
+    attestation.consumed = true;
+    attestation.consumer = Some(consumer.clone());
+    attestation.consumed_at = Some(env.ledger().sequence());
+
+    let config = storage::get_config(env)?;
+    storage::set_attestation(env, &attestation, config.attestation_ttl);
+    storage::with_stats(env, |s| {
+        s.attestations_consumed = s.attestations_consumed.saturating_add(1)
+    });
+    events::attestation_consumed(env, commitment, consumer);
+
+    Ok(attestation)
+}
+
+/// Administratively invalidate an attestation.
+///
+/// Needed when a policy is retroactively found unsound: the proofs are still
+/// mathematically valid, but the statement they prove is no longer one the
+/// platform wants to honour.
+pub fn revoke(env: &Env, caller: &Address, commitment: &Digest, reason: u32) -> Result<(), Error> {
+    storage::get_attestation(env, commitment)?;
+    storage::remove_attestation(env, commitment);
+    events::attestation_revoked(env, commitment, caller, reason);
+    Ok(())
+}
+
+/// Non-throwing status view for UIs and off-chain indexers.
+pub fn status(env: &Env, commitment: &Digest) -> AttestationStatus {
+    match storage::find_attestation(env, commitment) {
+        None => AttestationStatus {
+            exists: false,
+            valid: false,
+            consumed: false,
+            expired: false,
+            risk_score: 0,
+            policy_version: 0,
+        },
+        Some(a) => {
+            let expired = env.ledger().sequence() > a.expires_at;
+            AttestationStatus {
+                exists: true,
+                valid: !a.consumed && !expired,
+                consumed: a.consumed,
+                expired,
+                risk_score: a.risk_score,
+                policy_version: a.policy_version,
+            }
+        }
+    }
+}

--- a/contracts/zk_metadata_verifier/src/contract.rs
+++ b/contracts/zk_metadata_verifier/src/contract.rs
@@ -1,0 +1,551 @@
+//! The contract surface.
+//!
+//! Entrypoints are grouped as: lifecycle, roles, circuit registry, policy,
+//! verification, attestation, and queries. The verification group is the
+//! interesting one; everything else exists to make it governable.
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
+
+use crate::access;
+use crate::attestation;
+use crate::errors::Error;
+use crate::events;
+use crate::field::checked_scalar;
+use crate::groth16::{self, MAX_BATCH_SIZE};
+use crate::policy;
+use crate::registry;
+use crate::storage;
+use crate::types::{
+    Attestation, AttestationStatus, BatchOutcome, CircuitRecord, Config, Digest, Groth16Proof,
+    MetadataSignals, PendingRotation, Policy, PolicyParams, Role, ScalarBytes, Stats, VerifyingKey,
+};
+
+/// Default ledgers a verifying-key rotation must age before activation
+/// (~1 day at 5-second ledgers).
+pub const DEFAULT_ROTATION_TIMELOCK: u32 = 17_280;
+/// Default nullifier retention (~30 days).
+pub const DEFAULT_NULLIFIER_TTL: u32 = 518_400;
+/// Default attestation retention (~7 days).
+pub const DEFAULT_ATTESTATION_TTL: u32 = 120_960;
+
+#[contract]
+pub struct ZkMetadataVerifier;
+
+#[contractimpl]
+impl ZkMetadataVerifier {
+    // =======================================================================
+    // Lifecycle
+    // =======================================================================
+
+    /// One-time setup. `admin` becomes the root administrator.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if storage::is_initialized(&env) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+
+        storage::set_admin(&env, &admin);
+        storage::set_config(
+            &env,
+            &Config {
+                rotation_timelock: DEFAULT_ROTATION_TIMELOCK,
+                nullifier_ttl: DEFAULT_NULLIFIER_TTL,
+                attestation_ttl: DEFAULT_ATTESTATION_TTL,
+                max_batch_size: MAX_BATCH_SIZE,
+                require_issuer_auth: true,
+            },
+        );
+        storage::set_stats(&env, &Stats::new());
+        storage::set_paused(&env, false);
+        storage::mark_initialized(&env);
+        storage::bump_instance(&env);
+
+        events::initialized(&env, &admin);
+        Ok(())
+    }
+
+    /// Replace the tunable configuration. Admin only.
+    ///
+    /// Rejects a configuration where nullifiers would expire before the
+    /// attestations they protect — that ordering is the invariant the whole
+    /// replay defence rests on.
+    pub fn set_config(env: Env, caller: Address, config: Config) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::require_admin(&env, &caller)?;
+
+        if config.max_batch_size == 0 || config.max_batch_size > MAX_BATCH_SIZE {
+            return Err(Error::BatchTooLarge);
+        }
+        if config.nullifier_ttl <= config.attestation_ttl {
+            return Err(Error::InvalidPolicyParameters);
+        }
+
+        storage::set_config(&env, &config);
+        storage::bump_instance(&env);
+        events::config_updated(&env, &caller);
+        Ok(())
+    }
+
+    /// Halt verification. Holders of `Pauser` or the admin may call this.
+    pub fn pause(env: Env, caller: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::require_role(&env, &caller, Role::Pauser)?;
+        if storage::is_paused(&env) {
+            return Err(Error::Paused);
+        }
+        storage::set_paused(&env, true);
+        events::paused(&env, &caller);
+        Ok(())
+    }
+
+    /// Resume verification. Admin only — deliberately narrower than `pause`,
+    /// so an on-call responder can stop the bleeding without also holding the
+    /// key that restarts it.
+    pub fn unpause(env: Env, caller: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::require_admin(&env, &caller)?;
+        if !storage::is_paused(&env) {
+            return Err(Error::NotPaused);
+        }
+        storage::set_paused(&env, false);
+        events::unpaused(&env, &caller);
+        Ok(())
+    }
+
+    // =======================================================================
+    // Roles
+    // =======================================================================
+
+    pub fn grant_role(env: Env, caller: Address, role: Role, who: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::grant(&env, &caller, role, &who)
+    }
+
+    pub fn revoke_role(env: Env, caller: Address, role: Role, who: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::revoke(&env, &caller, role, &who)
+    }
+
+    pub fn transfer_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::transfer_admin(&env, &caller, &new_admin)
+    }
+
+    pub fn accept_admin(env: Env, caller: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::accept_admin(&env, &caller)
+    }
+
+    pub fn cancel_admin_transfer(env: Env, caller: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::cancel_admin_transfer(&env, &caller)
+    }
+
+    /// Authorize a lifecycle contract to redeem attestations.
+    pub fn register_consumer(env: Env, caller: Address, consumer: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::require_admin(&env, &caller)?;
+        if storage::has_role(&env, Role::Consumer, &consumer) {
+            return Err(Error::ConsumerAlreadyRegistered);
+        }
+        storage::grant_role(&env, Role::Consumer, &consumer);
+        events::consumer_registered(&env, &consumer, &caller);
+        Ok(())
+    }
+
+    // =======================================================================
+    // Circuit registry
+    // =======================================================================
+
+    pub fn register_circuit(
+        env: Env,
+        caller: Address,
+        circuit_id: Symbol,
+        vk: VerifyingKey,
+        num_public_inputs: u32,
+        provenance: String,
+    ) -> Result<Digest, Error> {
+        storage::require_initialized(&env)?;
+        storage::bump_instance(&env);
+        let record = registry::register_circuit(
+            &env,
+            &caller,
+            circuit_id,
+            vk,
+            num_public_inputs,
+            provenance,
+        )?;
+        Ok(record.vk_digest)
+    }
+
+    pub fn propose_rotation(
+        env: Env,
+        caller: Address,
+        circuit_id: Symbol,
+        vk: VerifyingKey,
+        num_public_inputs: u32,
+    ) -> Result<u32, Error> {
+        storage::require_initialized(&env)?;
+        storage::bump_instance(&env);
+        let rotation =
+            registry::propose_rotation(&env, &caller, circuit_id, vk, num_public_inputs)?;
+        Ok(rotation.eta)
+    }
+
+    pub fn cancel_rotation(env: Env, caller: Address, circuit_id: Symbol) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        registry::cancel_rotation(&env, &caller, circuit_id)
+    }
+
+    pub fn finalize_rotation(
+        env: Env,
+        caller: Address,
+        circuit_id: Symbol,
+    ) -> Result<Digest, Error> {
+        storage::require_initialized(&env)?;
+        storage::bump_instance(&env);
+        let record = registry::finalize_rotation(&env, &caller, circuit_id)?;
+        Ok(record.vk_digest)
+    }
+
+    pub fn set_circuit_enabled(
+        env: Env,
+        caller: Address,
+        circuit_id: Symbol,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        registry::set_circuit_enabled(&env, &caller, circuit_id, enabled)
+    }
+
+    pub fn freeze_circuit(env: Env, caller: Address, circuit_id: Symbol) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        registry::freeze_circuit(&env, &caller, circuit_id)
+    }
+
+    // =======================================================================
+    // Policy
+    // =======================================================================
+
+    pub fn publish_policy(env: Env, caller: Address, params: PolicyParams) -> Result<u32, Error> {
+        storage::require_initialized(&env)?;
+        storage::bump_instance(&env);
+        let p = policy::publish_policy(&env, &caller, params)?;
+        Ok(p.version)
+    }
+
+    pub fn activate_policy(env: Env, caller: Address, version: u32) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        storage::bump_instance(&env);
+        policy::activate_policy(&env, &caller, version)?;
+        Ok(())
+    }
+
+    // =======================================================================
+    // Verification
+    // =======================================================================
+
+    /// Stateless Groth16 check against a registered circuit.
+    ///
+    /// Useful for circuits other than the metadata validator, and for clients
+    /// that want to dry-run a proof before paying for the stateful path. It
+    /// writes nothing, spends no nullifier, and issues no attestation.
+    pub fn verify_proof(
+        env: Env,
+        circuit_id: Symbol,
+        proof: Groth16Proof,
+        public_inputs: Vec<ScalarBytes>,
+    ) -> Result<bool, Error> {
+        storage::require_initialized(&env)?;
+        storage::require_not_paused(&env)?;
+
+        let record = registry::active_circuit(&env, &circuit_id)?;
+        if public_inputs.len() != record.num_public_inputs {
+            return Err(Error::PublicInputCountMismatch);
+        }
+
+        groth16::verify_proof(&env, &record.vk, &proof, &public_inputs)?;
+        events::proof_verified(&env, &circuit_id, public_inputs.len());
+        Ok(true)
+    }
+
+    /// Non-throwing flavour of [`Self::verify_proof`], for simulation.
+    pub fn check_proof(
+        env: Env,
+        circuit_id: Symbol,
+        proof: Groth16Proof,
+        public_inputs: Vec<ScalarBytes>,
+    ) -> bool {
+        match registry::active_circuit(&env, &circuit_id) {
+            Ok(record) => {
+                record.num_public_inputs == public_inputs.len()
+                    && groth16::is_valid_proof(&env, &record.vk, &proof, &public_inputs)
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// The main entrypoint: verify an AI safety proof and issue an attestation.
+    ///
+    /// Ordering is deliberate and each step is a guard against a specific
+    /// attack:
+    ///
+    /// 1. **Policy checks** — cheap integer comparisons, and they bind the
+    ///    proof to the rules currently in force. Running them first means a
+    ///    proof against a retired policy costs the submitter a few hundred
+    ///    instructions rather than a full pairing.
+    /// 2. **Nullifier check** — before the pairing, so a replayed proof is
+    ///    rejected cheaply.
+    /// 3. **Pairing check** — the expensive part, reached only by a submission
+    ///    that is fresh and policy-conformant.
+    /// 4. **Spend and attest** — state writes last, so a failure anywhere above
+    ///    leaves no partial state.
+    pub fn verify_metadata(
+        env: Env,
+        issuer: Address,
+        proof: Groth16Proof,
+        signals: MetadataSignals,
+    ) -> Result<Attestation, Error> {
+        storage::require_initialized(&env)?;
+        storage::require_not_paused(&env)?;
+        storage::bump_instance(&env);
+
+        let config = storage::get_config(&env)?;
+        if config.require_issuer_auth {
+            issuer.require_auth();
+        }
+
+        let active = storage::active_policy(&env)?;
+        let mut record = registry::active_circuit(&env, &active.circuit_id)?;
+
+        // (1) policy semantics
+        policy::check_signals(&env, &active, &signals, &issuer)?;
+
+        // (2) replay
+        attestation::require_unspent(&env, &signals.nullifier)?;
+
+        // (3) the pairing
+        let public_inputs = policy::signals_to_public_inputs(&env, &signals);
+        if public_inputs.len() != record.num_public_inputs {
+            return Err(Error::PublicInputCountMismatch);
+        }
+        // No bookkeeping on the failure path: returning `Err` rolls the whole
+        // invocation back, so a counter bump or event here would vanish with
+        // it. See the note on [`Stats`].
+        groth16::verify_proof(&env, &record.vk, &proof, &public_inputs)?;
+
+        // (4) state
+        attestation::spend(&env, &signals.nullifier, &issuer, &config);
+        let att = attestation::issue(
+            &env,
+            &signals,
+            &issuer,
+            &active.circuit_id,
+            active.version,
+            &config,
+        );
+
+        registry::note_verification(&env, &mut record);
+        storage::with_stats(&env, |s| {
+            s.proofs_verified = s.proofs_verified.saturating_add(1)
+        });
+        events::proof_verified(&env, &active.circuit_id, public_inputs.len());
+
+        Ok(att)
+    }
+
+    /// Verify many proofs for one circuit with `n + 3` pairings.
+    ///
+    /// Stateless, like [`Self::verify_proof`]: batching is an optimization for
+    /// bulk auditing, not a path to bulk attestation. Issuing attestations in
+    /// bulk would require spending `n` nullifiers atomically, and a single
+    /// stale member would revert the whole batch — worse UX than `n` separate
+    /// calls, for no saving.
+    pub fn verify_batch(
+        env: Env,
+        circuit_id: Symbol,
+        proofs: Vec<Groth16Proof>,
+        inputs: Vec<Vec<ScalarBytes>>,
+    ) -> Result<bool, Error> {
+        storage::require_initialized(&env)?;
+        storage::require_not_paused(&env)?;
+
+        let config = storage::get_config(&env)?;
+        let record = registry::active_circuit(&env, &circuit_id)?;
+
+        groth16::verify_batch(
+            &env,
+            &record.vk,
+            &record.vk_digest,
+            &proofs,
+            &inputs,
+            config.max_batch_size,
+        )?;
+
+        storage::with_stats(&env, |s| {
+            s.batches_verified = s.batches_verified.saturating_add(1);
+            s.proofs_verified = s.proofs_verified.saturating_add(proofs.len() as u64);
+        });
+        events::batch_verified(&env, &circuit_id, proofs.len());
+        Ok(true)
+    }
+
+    /// Run the batch check and, if it fails, attribute the failure.
+    ///
+    /// Separated from [`Self::verify_batch`] because the fallback pass costs a
+    /// full `4n` pairings. A caller that only needs a yes/no should not pay for
+    /// blame attribution it will not read.
+    pub fn diagnose_batch(
+        env: Env,
+        circuit_id: Symbol,
+        proofs: Vec<Groth16Proof>,
+        inputs: Vec<Vec<ScalarBytes>>,
+    ) -> Result<BatchOutcome, Error> {
+        storage::require_initialized(&env)?;
+        let config = storage::get_config(&env)?;
+        let record = registry::active_circuit(&env, &circuit_id)?;
+
+        let size = proofs.len();
+        let aggregate = groth16::verify_batch(
+            &env,
+            &record.vk,
+            &record.vk_digest,
+            &proofs,
+            &inputs,
+            config.max_batch_size,
+        );
+
+        match aggregate {
+            Ok(()) => Ok(crate::types::empty_outcome(&env, size, true)),
+            Err(Error::EmptyBatch) => Err(Error::EmptyBatch),
+            Err(Error::BatchTooLarge) => Err(Error::BatchTooLarge),
+            Err(Error::BatchLengthMismatch) => Err(Error::BatchLengthMismatch),
+            Err(_) => Ok(BatchOutcome {
+                aggregate_ok: false,
+                size,
+                failed: groth16::locate_batch_failures(&env, &record.vk, &proofs, &inputs),
+            }),
+        }
+    }
+
+    // =======================================================================
+    // Attestations
+    // =======================================================================
+
+    /// Redeem an attestation. Only registered consumer contracts may call this.
+    pub fn consume_attestation(
+        env: Env,
+        consumer: Address,
+        metadata_commitment: Digest,
+        issuer: Address,
+    ) -> Result<Attestation, Error> {
+        storage::require_initialized(&env)?;
+        storage::require_not_paused(&env)?;
+        consumer.require_auth();
+
+        if !storage::has_role(&env, Role::Consumer, &consumer) {
+            return Err(Error::NotAuthorizedConsumer);
+        }
+        attestation::consume(&env, &consumer, &metadata_commitment, &issuer)
+    }
+
+    /// Invalidate an attestation. Policy admin or root admin.
+    pub fn revoke_attestation(
+        env: Env,
+        caller: Address,
+        metadata_commitment: Digest,
+        reason: u32,
+    ) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        access::require_role(&env, &caller, Role::PolicyAdmin)?;
+        attestation::revoke(&env, &caller, &metadata_commitment, reason)
+    }
+
+    // =======================================================================
+    // Queries
+    // =======================================================================
+
+    pub fn get_attestation(env: Env, metadata_commitment: Digest) -> Result<Attestation, Error> {
+        storage::get_attestation(&env, &metadata_commitment)
+    }
+
+    pub fn attestation_status(env: Env, metadata_commitment: Digest) -> AttestationStatus {
+        attestation::status(&env, &metadata_commitment)
+    }
+
+    pub fn is_nullifier_spent(env: Env, nullifier: Digest) -> bool {
+        storage::nullifier_spent_at(&env, &nullifier).is_some()
+    }
+
+    pub fn get_circuit(env: Env, circuit_id: Symbol) -> Result<CircuitRecord, Error> {
+        storage::get_circuit(&env, &circuit_id)
+    }
+
+    pub fn list_circuits(env: Env) -> Vec<Symbol> {
+        storage::circuit_index(&env)
+    }
+
+    pub fn get_rotation(env: Env, circuit_id: Symbol) -> Result<PendingRotation, Error> {
+        storage::get_rotation(&env, &circuit_id)
+    }
+
+    pub fn get_policy(env: Env, version: u32) -> Result<Policy, Error> {
+        storage::get_policy(&env, version)
+    }
+
+    pub fn get_active_policy(env: Env) -> Result<Policy, Error> {
+        storage::active_policy(&env)
+    }
+
+    pub fn list_policies(env: Env) -> Vec<u32> {
+        storage::policy_index(&env)
+    }
+
+    pub fn get_config(env: Env) -> Result<Config, Error> {
+        storage::get_config(&env)
+    }
+
+    pub fn get_stats(env: Env) -> Stats {
+        storage::get_stats(&env)
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        storage::get_admin(&env)
+    }
+
+    pub fn has_role(env: Env, role: Role, who: Address) -> bool {
+        access::check_role(&env, &who, role)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        storage::is_paused(&env)
+    }
+
+    pub fn issuer_attestation_count(env: Env, issuer: Address) -> u64 {
+        storage::issuer_count(&env, &issuer)
+    }
+
+    /// Recompute the issuer binding hash. Provers call this to learn the value
+    /// the circuit must be witnessed with, rather than reimplementing the
+    /// domain-separated hash off chain and getting it subtly wrong.
+    pub fn compute_issuer_hash(env: Env, issuer: Address) -> Digest {
+        policy::issuer_hash(&env, &issuer)
+    }
+
+    /// Fingerprint a verifying key without registering it, so an operator can
+    /// diff against their ceremony output before proposing a rotation.
+    pub fn compute_vk_digest(env: Env, vk: VerifyingKey, num_public_inputs: u32) -> Digest {
+        groth16::verifying_key_digest(&env, &vk, num_public_inputs)
+    }
+
+    /// Public-input encoding, exposed so clients can confirm the wire order the
+    /// contract expects matches the one their prover produced.
+    pub fn encode_signals(env: Env, signals: MetadataSignals) -> Vec<ScalarBytes> {
+        policy::signals_to_public_inputs(&env, &signals)
+    }
+
+    /// True when a 32-byte string is a canonical `Fr` element.
+    pub fn is_canonical_scalar(_env: Env, scalar: ScalarBytes) -> bool {
+        checked_scalar(&scalar).is_ok()
+    }
+}

--- a/contracts/zk_metadata_verifier/src/errors.rs
+++ b/contracts/zk_metadata_verifier/src/errors.rs
@@ -1,0 +1,122 @@
+//! Error taxonomy for the ZK metadata verifier.
+//!
+//! Codes are grouped by subsystem so that off-chain tooling can route failures
+//! without string matching:
+//!
+//! | Range       | Subsystem                          |
+//! |-------------|------------------------------------|
+//! | `1..=19`    | Lifecycle / access control         |
+//! | `20..=39`   | Circuit & verifying-key registry   |
+//! | `40..=59`   | Proof encoding & curve validation  |
+//! | `60..=79`   | Public-signal / policy semantics   |
+//! | `80..=99`   | Replay protection & attestations   |
+//! | `100..=119` | Batch verification                 |
+
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    // ---------------------------------------------------------------- 1..19
+    /// `initialize` called on an already-initialized instance.
+    AlreadyInitialized = 1,
+    /// A state-touching entrypoint was called before `initialize`.
+    NotInitialized = 2,
+    /// Caller does not hold the role required for this entrypoint.
+    Unauthorized = 3,
+    /// The contract is paused; only admin recovery paths remain open.
+    Paused = 4,
+    /// The contract is not paused, so `unpause` is a no-op.
+    NotPaused = 5,
+    /// Role handoff was attempted to an invalid target.
+    InvalidRoleTarget = 6,
+    /// Attempted to revoke the last remaining admin.
+    LastAdmin = 7,
+    /// A pending admin transfer does not exist or belongs to another address.
+    NoPendingTransfer = 8,
+
+    // --------------------------------------------------------------- 20..39
+    /// No verifying key is registered under this circuit id.
+    CircuitNotFound = 20,
+    /// A circuit with this id already exists; use `rotate_verifying_key`.
+    CircuitAlreadyExists = 21,
+    /// The circuit has been frozen and can no longer be rotated.
+    CircuitFrozen = 22,
+    /// The circuit is registered but administratively disabled.
+    CircuitDisabled = 23,
+    /// `ic.len()` must equal `num_public_inputs + 1`.
+    MalformedVerifyingKey = 24,
+    /// The declared public-input arity is outside the supported bounds.
+    UnsupportedArity = 25,
+    /// Rotation supplied a key identical to the active one.
+    VerifyingKeyUnchanged = 26,
+    /// The rotation timelock has not yet elapsed.
+    RotationTimelockActive = 27,
+    /// No verifying-key rotation is currently pending.
+    NoPendingRotation = 28,
+
+    // --------------------------------------------------------------- 40..59
+    /// A G1 point failed decoding or the subgroup check.
+    InvalidG1Point = 40,
+    /// A G2 point failed decoding or the subgroup check.
+    InvalidG2Point = 41,
+    /// A scalar was not a canonical field element (>= r).
+    NonCanonicalScalar = 42,
+    /// The number of supplied public inputs disagrees with the circuit.
+    PublicInputCountMismatch = 43,
+    /// The pairing equation did not hold: the proof is invalid.
+    ProofVerificationFailed = 44,
+    /// A proof component decoded to the point at infinity where forbidden.
+    PointAtInfinity = 45,
+
+    // --------------------------------------------------------------- 60..79
+    /// No policy has been published yet.
+    PolicyNotFound = 60,
+    /// The referenced policy version is not the active one.
+    PolicyNotActive = 61,
+    /// The proof commits to a policy root the contract does not recognise.
+    PolicyRootMismatch = 62,
+    /// The proof commits to an unapproved scoring-model commitment.
+    ModelCommitmentMismatch = 63,
+    /// `risk_score` exceeds the policy's tolerated maximum.
+    RiskScoreTooHigh = 64,
+    /// The circuit's boolean verdict signal was not `1` (safe).
+    VerdictRejected = 65,
+    /// The attestation's `expiry_ledger` is in the past.
+    ProofExpired = 66,
+    /// `expiry_ledger` is further out than the policy's maximum validity.
+    ExpiryTooDistant = 67,
+    /// The proof was bound to a different issuer than the caller.
+    IssuerBindingMismatch = 68,
+    /// A published policy carried nonsensical parameters.
+    InvalidPolicyParameters = 69,
+    /// The policy version supplied is not newer than the active one.
+    PolicyVersionRegression = 70,
+
+    // --------------------------------------------------------------- 80..99
+    /// The nullifier has already been consumed: this is a replay.
+    NullifierAlreadyUsed = 80,
+    /// No attestation exists for the supplied metadata commitment.
+    AttestationNotFound = 81,
+    /// The attestation has already been consumed by the mint lifecycle.
+    AttestationAlreadyConsumed = 82,
+    /// The attestation has passed its expiry ledger.
+    AttestationExpired = 83,
+    /// Only a registered consumer contract may consume attestations.
+    NotAuthorizedConsumer = 84,
+    /// The consumer address is already registered.
+    ConsumerAlreadyRegistered = 85,
+    /// The metadata commitment does not match the attestation on record.
+    CommitmentMismatch = 86,
+
+    // ------------------------------------------------------------- 100..119
+    /// A batch must contain at least one proof.
+    EmptyBatch = 100,
+    /// The batch exceeds `MAX_BATCH_SIZE`.
+    BatchTooLarge = 101,
+    /// Proof and public-input vectors have different lengths.
+    BatchLengthMismatch = 102,
+    /// Aggregate pairing check failed; at least one proof is invalid.
+    BatchVerificationFailed = 103,
+}

--- a/contracts/zk_metadata_verifier/src/events.rs
+++ b/contracts/zk_metadata_verifier/src/events.rs
@@ -1,0 +1,209 @@
+//! Event emission.
+//!
+//! Topics follow the repository convention of `(subject, action, [key])` so
+//! indexers can subscribe narrowly. Every event that reports a verification
+//! carries the circuit id and policy version, because a proof is only
+//! meaningful relative to the rules it was checked against — an indexer that
+//! records "metadata approved" without recording *which policy approved it*
+//! cannot answer the only question that matters after a rule change.
+
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use crate::types::{Digest, Role};
+
+const VERIFIER: Symbol = symbol_short!("verifier");
+const CIRCUIT: Symbol = symbol_short!("circuit");
+const POLICY: Symbol = symbol_short!("policy");
+const ATTEST: Symbol = symbol_short!("attest");
+const NULLIF: Symbol = symbol_short!("nullif");
+const ROLE: Symbol = symbol_short!("role");
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+pub fn initialized(env: &Env, admin: &Address) {
+    env.events()
+        .publish((VERIFIER, symbol_short!("init")), admin.clone());
+}
+
+pub fn paused(env: &Env, by: &Address) {
+    env.events()
+        .publish((VERIFIER, symbol_short!("paused")), by.clone());
+}
+
+pub fn unpaused(env: &Env, by: &Address) {
+    env.events()
+        .publish((VERIFIER, symbol_short!("unpaused")), by.clone());
+}
+
+pub fn config_updated(env: &Env, by: &Address) {
+    env.events()
+        .publish((VERIFIER, symbol_short!("config")), by.clone());
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+pub fn role_granted(env: &Env, role: Role, who: &Address, by: &Address) {
+    env.events().publish(
+        (ROLE, symbol_short!("granted"), who.clone()),
+        (role, by.clone()),
+    );
+}
+
+pub fn role_revoked(env: &Env, role: Role, who: &Address, by: &Address) {
+    env.events().publish(
+        (ROLE, symbol_short!("revoked"), who.clone()),
+        (role, by.clone()),
+    );
+}
+
+pub fn admin_transfer_started(env: &Env, from: &Address, to: &Address) {
+    env.events().publish(
+        (ROLE, symbol_short!("xfer_req")),
+        (from.clone(), to.clone()),
+    );
+}
+
+pub fn admin_transfer_completed(env: &Env, from: &Address, to: &Address) {
+    env.events()
+        .publish((ROLE, symbol_short!("xfer_ok")), (from.clone(), to.clone()));
+}
+
+// ---------------------------------------------------------------------------
+// Circuit registry
+// ---------------------------------------------------------------------------
+
+pub fn circuit_registered(
+    env: &Env,
+    circuit_id: &Symbol,
+    digest: &Digest,
+    arity: u32,
+    by: &Address,
+) {
+    env.events().publish(
+        (CIRCUIT, symbol_short!("register"), circuit_id.clone()),
+        (digest.clone(), arity, by.clone()),
+    );
+}
+
+pub fn rotation_proposed(env: &Env, circuit_id: &Symbol, digest: &Digest, eta: u32, by: &Address) {
+    env.events().publish(
+        (CIRCUIT, symbol_short!("rot_prop"), circuit_id.clone()),
+        (digest.clone(), eta, by.clone()),
+    );
+}
+
+pub fn rotation_cancelled(env: &Env, circuit_id: &Symbol, by: &Address) {
+    env.events().publish(
+        (CIRCUIT, symbol_short!("rot_cncl"), circuit_id.clone()),
+        by.clone(),
+    );
+}
+
+pub fn rotation_finalized(
+    env: &Env,
+    circuit_id: &Symbol,
+    old_digest: &Digest,
+    new_digest: &Digest,
+    revision: u32,
+) {
+    env.events().publish(
+        (CIRCUIT, symbol_short!("rot_done"), circuit_id.clone()),
+        (old_digest.clone(), new_digest.clone(), revision),
+    );
+}
+
+pub fn circuit_enabled(env: &Env, circuit_id: &Symbol, enabled: bool, by: &Address) {
+    env.events().publish(
+        (CIRCUIT, symbol_short!("enabled"), circuit_id.clone()),
+        (enabled, by.clone()),
+    );
+}
+
+pub fn circuit_frozen(env: &Env, circuit_id: &Symbol, by: &Address) {
+    env.events().publish(
+        (CIRCUIT, symbol_short!("frozen"), circuit_id.clone()),
+        by.clone(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+pub fn policy_published(env: &Env, version: u32, root: &Digest, by: &Address) {
+    env.events().publish(
+        (POLICY, symbol_short!("publish"), version),
+        (root.clone(), by.clone()),
+    );
+}
+
+pub fn policy_activated(env: &Env, version: u32, previous: u32, by: &Address) {
+    env.events().publish(
+        (POLICY, symbol_short!("activate"), version),
+        (previous, by.clone()),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+pub fn proof_verified(env: &Env, circuit_id: &Symbol, inputs: u32) {
+    env.events().publish(
+        (VERIFIER, symbol_short!("proof_ok"), circuit_id.clone()),
+        inputs,
+    );
+}
+
+pub fn batch_verified(env: &Env, circuit_id: &Symbol, size: u32) {
+    env.events().publish(
+        (VERIFIER, symbol_short!("batch_ok"), circuit_id.clone()),
+        size,
+    );
+}
+
+pub fn nullifier_spent(env: &Env, nullifier: &Digest, issuer: &Address) {
+    env.events().publish(
+        (NULLIF, symbol_short!("spent"), nullifier.clone()),
+        issuer.clone(),
+    );
+}
+
+pub fn attestation_issued(
+    env: &Env,
+    commitment: &Digest,
+    issuer: &Address,
+    risk_score: u32,
+    policy_version: u32,
+    expires_at: u32,
+) {
+    env.events().publish(
+        (ATTEST, symbol_short!("issued"), commitment.clone()),
+        (issuer.clone(), risk_score, policy_version, expires_at),
+    );
+}
+
+pub fn attestation_consumed(env: &Env, commitment: &Digest, consumer: &Address) {
+    env.events().publish(
+        (ATTEST, symbol_short!("consumed"), commitment.clone()),
+        consumer.clone(),
+    );
+}
+
+pub fn attestation_revoked(env: &Env, commitment: &Digest, by: &Address, reason: u32) {
+    env.events().publish(
+        (ATTEST, symbol_short!("revoked"), commitment.clone()),
+        (by.clone(), reason),
+    );
+}
+
+pub fn consumer_registered(env: &Env, consumer: &Address, by: &Address) {
+    env.events().publish(
+        (ATTEST, symbol_short!("consumer")),
+        (consumer.clone(), by.clone()),
+    );
+}

--- a/contracts/zk_metadata_verifier/src/field.rs
+++ b/contracts/zk_metadata_verifier/src/field.rs
@@ -1,0 +1,229 @@
+//! Scalar-field helpers for BLS12-381.
+//!
+//! Two jobs live here:
+//!
+//! 1. **Canonicality.** The host will happily interpret any 32-byte string as a
+//!    scalar, reducing it mod `r`. For *public inputs* that is unsafe: it makes
+//!    the statement malleable, since `x` and `x + r` would produce identical
+//!    verification results but different transaction payloads. Every scalar
+//!    that enters verification passes [`checked_scalar`] first.
+//!
+//! 2. **Fiat–Shamir.** Batch verification needs random coefficients that the
+//!    prover cannot choose. Deriving them from a transcript over the whole
+//!    batch (rather than from `env.prng()`) keeps the check sound even against
+//!    a submitter who can observe ledger state.
+
+use soroban_sdk::{crypto::bls12_381::Fr, Bytes, BytesN, Env, U256};
+
+use crate::errors::Error;
+use crate::types::ScalarBytes;
+
+/// The BLS12-381 subgroup order `r`, big-endian.
+///
+/// `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
+pub const FR_MODULUS_BE: [u8; 32] = [
+    0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48, 0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+    0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01,
+];
+
+/// Domain separation tag mixed into every batch transcript. Changing this
+/// invalidates nothing on chain but prevents challenges from one deployment
+/// being replayed as challenges in another.
+pub const BATCH_DST: &[u8] = b"SOROMINT-ZK-METADATA-GROTH16-BATCH-V1";
+
+/// Domain separation tag for verifying-key digests.
+pub const VK_DIGEST_DST: &[u8] = b"SOROMINT-ZK-METADATA-VK-DIGEST-V1";
+
+/// Domain separation tag for issuer address binding.
+pub const ISSUER_DST: &[u8] = b"SOROMINT-ZK-METADATA-ISSUER-V1";
+
+/// Returns `true` when `bytes` encodes a value strictly less than `r`.
+///
+/// Comparison is a plain big-endian lexicographic walk: the first differing
+/// byte decides. Constant-time behaviour is irrelevant here because both
+/// operands are public.
+pub fn is_canonical(bytes: &ScalarBytes) -> bool {
+    let v = bytes.to_array();
+    let mut i = 0usize;
+    while i < 32 {
+        if v[i] != FR_MODULUS_BE[i] {
+            return v[i] < FR_MODULUS_BE[i];
+        }
+        i += 1;
+    }
+    // Exactly equal to r — not canonical (r ≡ 0, and 0 has the encoding of 0).
+    false
+}
+
+/// Validate and lift a 32-byte big-endian scalar into an `Fr`.
+pub fn checked_scalar(bytes: &ScalarBytes) -> Result<Fr, Error> {
+    if !is_canonical(bytes) {
+        return Err(Error::NonCanonicalScalar);
+    }
+    Ok(Fr::from_bytes(bytes.clone()))
+}
+
+/// Lift a small unsigned integer into `Fr`. Always canonical.
+pub fn scalar_from_u32(env: &Env, value: u32) -> Fr {
+    Fr::from_u256(U256::from_u32(env, value))
+}
+
+/// Lift a `u64` into `Fr`. Always canonical.
+pub fn scalar_from_u64(env: &Env, value: u64) -> Fr {
+    // U256::from_u128 is the widest small-int constructor exposed by the SDK.
+    Fr::from_u256(U256::from_u128(env, value as u128))
+}
+
+/// The additive identity of `Fr`.
+pub fn scalar_zero(env: &Env) -> Fr {
+    Fr::from_u256(U256::from_u32(env, 0))
+}
+
+/// The multiplicative identity of `Fr`.
+pub fn scalar_one(env: &Env) -> Fr {
+    Fr::from_u256(U256::from_u32(env, 1))
+}
+
+/// Encode a `u32` as a 32-byte big-endian scalar. Used when a public signal is
+/// semantically an integer (verdict, risk score, ledger number) but must be
+/// presented to the pairing check as a field element.
+pub fn u32_to_scalar_bytes(env: &Env, value: u32) -> ScalarBytes {
+    let mut buf = [0u8; 32];
+    buf[28..32].copy_from_slice(&value.to_be_bytes());
+    BytesN::from_array(env, &buf)
+}
+
+/// A rolling Fiat–Shamir transcript over SHA-256.
+///
+/// Absorb everything that the challenge must depend on, then `challenge(i)` to
+/// squeeze coefficient `i`. Squeezing does not mutate the absorbed state, so
+/// coefficients are a deterministic function of the whole batch — reordering
+/// the batch changes every coefficient.
+pub struct Transcript {
+    env: Env,
+    buf: Bytes,
+}
+
+impl Transcript {
+    /// Start a transcript seeded with a domain separation tag.
+    pub fn new(env: &Env, dst: &[u8]) -> Self {
+        let mut buf = Bytes::new(env);
+        buf.extend_from_slice(dst);
+        Self {
+            env: env.clone(),
+            buf,
+        }
+    }
+
+    /// Absorb raw bytes.
+    pub fn absorb_bytes(&mut self, bytes: &Bytes) {
+        self.buf.append(bytes);
+    }
+
+    /// Absorb a fixed-width byte string.
+    pub fn absorb_n<const N: usize>(&mut self, bytes: &BytesN<N>) {
+        self.buf.extend_from_array(&bytes.to_array());
+    }
+
+    /// Absorb a slice literal (tags, separators).
+    pub fn absorb_slice(&mut self, bytes: &[u8]) {
+        self.buf.extend_from_slice(bytes);
+    }
+
+    /// Absorb a `u32` in big-endian form.
+    pub fn absorb_u32(&mut self, value: u32) {
+        self.buf.extend_from_array(&value.to_be_bytes());
+    }
+
+    /// Squeeze challenge number `index`.
+    ///
+    /// The top byte of the SHA-256 output is cleared, bounding the result by
+    /// `2^248 < r`. That costs eight bits of challenge entropy and buys an
+    /// unconditional canonicality guarantee — a fine trade when the soundness
+    /// error is `batch_size / 2^248`.
+    pub fn challenge(&self, index: u32) -> Fr {
+        let mut material = self.buf.clone();
+        material.extend_from_slice(b"|chal|");
+        material.extend_from_array(&index.to_be_bytes());
+        let digest = self.env.crypto().sha256(&material);
+        let mut arr = digest.to_array();
+        arr[0] = 0;
+        Fr::from_bytes(BytesN::from_array(&self.env, &arr))
+    }
+
+    /// Finalize into a plain digest (used for VK fingerprints).
+    pub fn finalize(&self) -> BytesN<32> {
+        self.env.crypto().sha256(&self.buf).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn zero_is_canonical() {
+        let env = Env::default();
+        let z = BytesN::from_array(&env, &[0u8; 32]);
+        assert!(is_canonical(&z));
+    }
+
+    #[test]
+    fn modulus_itself_is_not_canonical() {
+        let env = Env::default();
+        let m = BytesN::from_array(&env, &FR_MODULUS_BE);
+        assert!(!is_canonical(&m));
+    }
+
+    #[test]
+    fn modulus_minus_one_is_canonical() {
+        let env = Env::default();
+        let mut m = FR_MODULUS_BE;
+        m[31] -= 1;
+        assert!(is_canonical(&BytesN::from_array(&env, &m)));
+    }
+
+    #[test]
+    fn all_ones_is_not_canonical() {
+        let env = Env::default();
+        let m = BytesN::from_array(&env, &[0xffu8; 32]);
+        assert!(!is_canonical(&m));
+    }
+
+    #[test]
+    fn u32_round_trips_through_scalar_bytes() {
+        let env = Env::default();
+        let b = u32_to_scalar_bytes(&env, 0xDEAD_BEEF);
+        let arr = b.to_array();
+        assert_eq!(&arr[28..32], &0xDEAD_BEEFu32.to_be_bytes());
+        assert!(is_canonical(&b));
+    }
+
+    #[test]
+    fn challenges_differ_by_index() {
+        let env = Env::default();
+        let t = Transcript::new(&env, BATCH_DST);
+        assert_ne!(t.challenge(0).to_bytes(), t.challenge(1).to_bytes());
+    }
+
+    #[test]
+    fn challenges_depend_on_absorbed_state() {
+        let env = Env::default();
+        let mut a = Transcript::new(&env, BATCH_DST);
+        let mut b = Transcript::new(&env, BATCH_DST);
+        a.absorb_u32(1);
+        b.absorb_u32(2);
+        assert_ne!(a.challenge(0).to_bytes(), b.challenge(0).to_bytes());
+    }
+
+    #[test]
+    fn challenges_are_canonical() {
+        let env = Env::default();
+        let mut t = Transcript::new(&env, BATCH_DST);
+        t.absorb_slice(b"some batch material");
+        for i in 0..16u32 {
+            assert!(is_canonical(&t.challenge(i).to_bytes()));
+        }
+    }
+}

--- a/contracts/zk_metadata_verifier/src/groth16.rs
+++ b/contracts/zk_metadata_verifier/src/groth16.rs
@@ -1,0 +1,646 @@
+//! Groth16 verification over BLS12-381, implemented against the Soroban host's
+//! native curve functions.
+//!
+//! # The equation
+//!
+//! A Groth16 proof `(A, B, C)` for a statement with public inputs
+//! `x = (x_1, …, x_n)` verifies iff
+//!
+//! ```text
+//! e(A, B) = e(α, β) · e(L, γ) · e(C, δ)      where  L = IC_0 + Σ_j x_j · IC_j
+//! ```
+//!
+//! The host exposes a *multi-pairing product* check rather than individual
+//! pairings, so the equation is rearranged to put everything on one side:
+//!
+//! ```text
+//! e(−A, B) · e(α, β) · e(L, γ) · e(C, δ) = 1
+//! ```
+//!
+//! That is a single `pairing_check` over four pairs — one Miller loop batch and
+//! one final exponentiation, instead of four of each. On Soroban this is the
+//! difference between a verification that fits comfortably in a transaction's
+//! resource budget and one that does not.
+//!
+//! # What is checked, and why
+//!
+//! * **Encoding flags.** The host panics on malformed flag bits. A panic aborts
+//!   the whole transaction with an opaque error, so flags are pre-validated
+//!   here and surfaced as [`Error::InvalidG1Point`] / [`Error::InvalidG2Point`].
+//! * **Coordinate range.** Same reasoning: coordinates ≥ `p` are rejected
+//!   before they reach the host.
+//! * **Subgroup membership.** BLS12-381's G1 and G2 are proper subgroups of
+//!   their curve groups. A point on the curve but outside the subgroup breaks
+//!   the pairing's bilinearity and lets an attacker forge. The host's
+//!   `g1_is_in_subgroup` / `g2_is_in_subgroup` do the cofactor clearing check.
+//!   This is the single most commonly omitted check in hand-rolled verifiers.
+//! * **Point at infinity.** Degenerate proof elements are refused. An honest
+//!   prover hits this with probability ≈ 2⁻²⁵⁵, so completeness is unaffected.
+//! * **Scalar canonicality.** See [`crate::field`].
+//!
+//! Verifying-key points are validated once at registration rather than on every
+//! verification, since the registry is governance-controlled and immutable
+//! between rotations.
+//!
+//! # What this module cannot turn into a clean error
+//!
+//! One check is missing from the list above: **curve membership** (`y² = x³+4`
+//! for G1, its Fp2 analogue for G2). The SDK exposes `Fp` addition and negation
+//! but no multiplication, so the equation cannot be evaluated here. The host
+//! does evaluate it, during deserialization — but it reports failure by
+//! *trapping*, and a Soroban guest cannot catch a host trap.
+//!
+//! The security consequence is nil: an off-curve point is still rejected, and
+//! the transaction still fails. The ergonomic consequence is that the caller
+//! sees a host error rather than [`Error::InvalidG1Point`]. The pre-checks in
+//! this module exist precisely to keep every *other* malformed input on the
+//! clean-error path, so a host trap becomes a reliable signal of exactly one
+//! condition: a point that is well-formed and in range but not on the curve.
+
+use soroban_sdk::{
+    crypto::bls12_381::{Fr, G1Affine, G2Affine},
+    Env, Vec,
+};
+
+use crate::errors::Error;
+use crate::field::{checked_scalar, scalar_zero, Transcript, BATCH_DST, VK_DIGEST_DST};
+use crate::types::{Digest, G1Bytes, G2Bytes, Groth16Proof, ScalarBytes, VerifyingKey};
+
+/// The BLS12-381 base field modulus `p`, big-endian, 48 bytes.
+pub const FP_MODULUS_BE: [u8; 48] = [
+    0x1a, 0x01, 0x11, 0xea, 0x39, 0x7f, 0xe6, 0x9a, 0x4b, 0x1b, 0xa7, 0xb6, 0x43, 0x4b, 0xac, 0xd7,
+    0x64, 0x77, 0x4b, 0x84, 0xf3, 0x85, 0x12, 0xbf, 0x67, 0x30, 0xd2, 0xa0, 0xf6, 0xb0, 0xf6, 0x24,
+    0x1e, 0xab, 0xff, 0xfe, 0xb1, 0x53, 0xff, 0xff, 0xb9, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xaa, 0xab,
+];
+
+/// Compression flag — must always be clear (only uncompressed points).
+const FLAG_COMPRESSION: u8 = 0x80;
+/// Infinity flag.
+const FLAG_INFINITY: u8 = 0x40;
+/// Sort flag — must always be clear.
+const FLAG_SORT: u8 = 0x20;
+/// Mask isolating the flag bits.
+const FLAG_MASK: u8 = 0xE0;
+
+/// Largest public-input arity the contract will register a circuit for.
+///
+/// Each additional input costs one G1 scalar multiplication inside the MSM.
+/// Thirty-two is far above what the metadata circuit needs (eight) and still
+/// leaves headroom in the CPU budget for the four pairings.
+pub const MAX_PUBLIC_INPUTS: u32 = 32;
+
+/// Largest batch the aggregate verifier will accept in one call.
+pub const MAX_BATCH_SIZE: u32 = 16;
+
+// ---------------------------------------------------------------------------
+// Encoding validation
+// ---------------------------------------------------------------------------
+
+/// True when a 48-byte big-endian limb is a valid `Fp` element (`< p`).
+///
+/// `masked_first` lets the caller strip flag bits from byte 0 before the
+/// comparison; `p`'s leading byte is `0x1a`, so the three flag bits never
+/// overlap a significant bit of a valid coordinate.
+fn fp_in_range(limb: &[u8], masked_first: bool) -> bool {
+    debug_assert!(limb.len() == 48);
+    let mut i = 0usize;
+    while i < 48 {
+        let lhs = if i == 0 && masked_first {
+            limb[0] & !FLAG_MASK
+        } else {
+            limb[i]
+        };
+        if lhs != FP_MODULUS_BE[i] {
+            return lhs < FP_MODULUS_BE[i];
+        }
+        i += 1;
+    }
+    false
+}
+
+/// True when the encoding has the infinity flag set.
+pub fn g1_is_infinity(bytes: &G1Bytes) -> bool {
+    (bytes.to_array()[0] & FLAG_INFINITY) != 0
+}
+
+/// True when the encoding has the infinity flag set.
+pub fn g2_is_infinity(bytes: &G2Bytes) -> bool {
+    (bytes.to_array()[0] & FLAG_INFINITY) != 0
+}
+
+/// Structural validation of a serialized G1 point, before it reaches the host.
+///
+/// A correctly flagged point at infinity is accepted here; callers that cannot
+/// tolerate infinity reject it separately, so that the two failure modes stay
+/// distinguishable in the error code.
+fn g1_wellformed(bytes: &G1Bytes) -> Result<(), Error> {
+    let arr = bytes.to_array();
+    let flags = arr[0] & FLAG_MASK;
+
+    if flags & FLAG_COMPRESSION != 0 || flags & FLAG_SORT != 0 {
+        return Err(Error::InvalidG1Point);
+    }
+
+    if flags & FLAG_INFINITY != 0 {
+        // Infinity must be encoded as the flag alone: every other bit zero.
+        if arr[0] & !FLAG_MASK != 0 {
+            return Err(Error::InvalidG1Point);
+        }
+        let mut i = 1usize;
+        while i < 96 {
+            if arr[i] != 0 {
+                return Err(Error::InvalidG1Point);
+            }
+            i += 1;
+        }
+        return Ok(());
+    }
+
+    if !fp_in_range(&arr[0..48], true) || !fp_in_range(&arr[48..96], false) {
+        return Err(Error::InvalidG1Point);
+    }
+    Ok(())
+}
+
+/// Structural validation of a serialized G2 point.
+fn g2_wellformed(bytes: &G2Bytes) -> Result<(), Error> {
+    let arr = bytes.to_array();
+    let flags = arr[0] & FLAG_MASK;
+
+    if flags & FLAG_COMPRESSION != 0 || flags & FLAG_SORT != 0 {
+        return Err(Error::InvalidG2Point);
+    }
+
+    if flags & FLAG_INFINITY != 0 {
+        if arr[0] & !FLAG_MASK != 0 {
+            return Err(Error::InvalidG2Point);
+        }
+        let mut i = 1usize;
+        while i < 192 {
+            if arr[i] != 0 {
+                return Err(Error::InvalidG2Point);
+            }
+            i += 1;
+        }
+        return Ok(());
+    }
+
+    // Four Fp limbs: X_c1, X_c0, Y_c1, Y_c0. Only the first carries flags.
+    if !fp_in_range(&arr[0..48], true)
+        || !fp_in_range(&arr[48..96], false)
+        || !fp_in_range(&arr[96..144], false)
+        || !fp_in_range(&arr[144..192], false)
+    {
+        return Err(Error::InvalidG2Point);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+// ---------------------------------------------------------------------------
+
+/// Decode a G1 point with full validation, including the subgroup check.
+///
+/// `allow_infinity` should be `false` for proof elements and `true` only where
+/// the identity is a legitimate value (an unused `IC` base, for instance).
+pub fn decode_g1(env: &Env, bytes: &G1Bytes, allow_infinity: bool) -> Result<G1Affine, Error> {
+    g1_wellformed(bytes)?;
+    let infinity = g1_is_infinity(bytes);
+    if infinity && !allow_infinity {
+        return Err(Error::PointAtInfinity);
+    }
+    let point = G1Affine::from_bytes(bytes.clone());
+    if !infinity && !env.crypto().bls12_381().g1_is_in_subgroup(&point) {
+        return Err(Error::InvalidG1Point);
+    }
+    Ok(point)
+}
+
+/// Decode a G2 point with full validation, including the subgroup check.
+pub fn decode_g2(env: &Env, bytes: &G2Bytes, allow_infinity: bool) -> Result<G2Affine, Error> {
+    g2_wellformed(bytes)?;
+    let infinity = g2_is_infinity(bytes);
+    if infinity && !allow_infinity {
+        return Err(Error::PointAtInfinity);
+    }
+    let point = G2Affine::from_bytes(bytes.clone());
+    if !infinity && !env.crypto().bls12_381().g2_is_in_subgroup(&point) {
+        return Err(Error::InvalidG2Point);
+    }
+    Ok(point)
+}
+
+// ---------------------------------------------------------------------------
+// Verifying key handling
+// ---------------------------------------------------------------------------
+
+/// Validate every point in a verifying key and confirm its arity.
+///
+/// Run once, at registration. `ic` must hold exactly `num_public_inputs + 1`
+/// bases; a mismatch there is the classic way a verifier silently accepts
+/// proofs for a different statement than the operator believes.
+pub fn validate_verifying_key(
+    env: &Env,
+    vk: &VerifyingKey,
+    num_public_inputs: u32,
+) -> Result<(), Error> {
+    if num_public_inputs > MAX_PUBLIC_INPUTS {
+        return Err(Error::UnsupportedArity);
+    }
+    if vk.ic.len() != num_public_inputs + 1 {
+        return Err(Error::MalformedVerifyingKey);
+    }
+
+    // α, β, γ, δ must all be non-degenerate: a δ or γ at infinity would make
+    // the corresponding pairing term vanish and neuter the constraint it
+    // enforces.
+    decode_g1(env, &vk.alpha_g1, false)?;
+    decode_g2(env, &vk.beta_g2, false)?;
+    decode_g2(env, &vk.gamma_g2, false)?;
+    decode_g2(env, &vk.delta_g2, false)?;
+
+    for base in vk.ic.iter() {
+        // An IC base may legitimately be the identity when the corresponding
+        // public wire is unconstrained in the circuit.
+        decode_g1(env, &base, true)?;
+    }
+    Ok(())
+}
+
+/// SHA-256 fingerprint over the canonical serialization of a verifying key.
+///
+/// Operators compare this against the digest their local `snarkjs zkey export`
+/// produces. Because it covers the arity and every point in order, two keys
+/// with the same digest are byte-identical.
+pub fn verifying_key_digest(env: &Env, vk: &VerifyingKey, num_public_inputs: u32) -> Digest {
+    let mut t = Transcript::new(env, VK_DIGEST_DST);
+    t.absorb_u32(num_public_inputs);
+    t.absorb_n(&vk.alpha_g1);
+    t.absorb_n(&vk.beta_g2);
+    t.absorb_n(&vk.gamma_g2);
+    t.absorb_n(&vk.delta_g2);
+    t.absorb_u32(vk.ic.len());
+    for base in vk.ic.iter() {
+        t.absorb_n(&base);
+    }
+    t.finalize()
+}
+
+// ---------------------------------------------------------------------------
+// Public input commitment
+// ---------------------------------------------------------------------------
+
+/// Compute `L = IC_0 + Σ_j x_j · IC_j` with a single host MSM.
+///
+/// The constant base `IC_0` is folded into the MSM with scalar `1` rather than
+/// added afterwards; one `g1_msm` of width `n+1` is cheaper than an MSM of
+/// width `n` plus a `g1_add`, and it keeps the code path uniform when `n = 0`.
+pub fn public_input_commitment(
+    env: &Env,
+    vk: &VerifyingKey,
+    public_inputs: &Vec<ScalarBytes>,
+) -> Result<G1Affine, Error> {
+    let n = public_inputs.len();
+    if vk.ic.len() != n + 1 {
+        return Err(Error::PublicInputCountMismatch);
+    }
+
+    let mut bases: Vec<G1Affine> = Vec::new(env);
+    let mut scalars: Vec<Fr> = Vec::new(env);
+
+    bases.push_back(G1Affine::from_bytes(vk.ic.get_unchecked(0)));
+    scalars.push_back(crate::field::scalar_one(env));
+
+    for j in 0..n {
+        let scalar = checked_scalar(&public_inputs.get_unchecked(j))?;
+        bases.push_back(G1Affine::from_bytes(vk.ic.get_unchecked(j + 1)));
+        scalars.push_back(scalar);
+    }
+
+    Ok(env.crypto().bls12_381().g1_msm(bases, scalars))
+}
+
+// ---------------------------------------------------------------------------
+// Single-proof verification
+// ---------------------------------------------------------------------------
+
+/// Verify one Groth16 proof. Returns `Ok(())` only when the pairing holds.
+///
+/// The verifying key is assumed pre-validated (see [`validate_verifying_key`]);
+/// the proof is not, and is fully checked here.
+pub fn verify_proof(
+    env: &Env,
+    vk: &VerifyingKey,
+    proof: &Groth16Proof,
+    public_inputs: &Vec<ScalarBytes>,
+) -> Result<(), Error> {
+    let a = decode_g1(env, &proof.a, false)?;
+    let b = decode_g2(env, &proof.b, false)?;
+    let c = decode_g1(env, &proof.c, false)?;
+
+    let l = public_input_commitment(env, vk, public_inputs)?;
+
+    let alpha = G1Affine::from_bytes(vk.alpha_g1.clone());
+    let beta = G2Affine::from_bytes(vk.beta_g2.clone());
+    let gamma = G2Affine::from_bytes(vk.gamma_g2.clone());
+    let delta = G2Affine::from_bytes(vk.delta_g2.clone());
+
+    let mut g1: Vec<G1Affine> = Vec::new(env);
+    let mut g2: Vec<G2Affine> = Vec::new(env);
+
+    // e(−A, B) · e(α, β) · e(L, γ) · e(C, δ) == 1
+    g1.push_back(-a);
+    g2.push_back(b);
+    g1.push_back(alpha);
+    g2.push_back(beta);
+    g1.push_back(l);
+    g2.push_back(gamma);
+    g1.push_back(c);
+    g2.push_back(delta);
+
+    if env.crypto().bls12_381().pairing_check(g1, g2) {
+        Ok(())
+    } else {
+        Err(Error::ProofVerificationFailed)
+    }
+}
+
+/// Boolean flavour of [`verify_proof`] for read-only queries.
+pub fn is_valid_proof(
+    env: &Env,
+    vk: &VerifyingKey,
+    proof: &Groth16Proof,
+    public_inputs: &Vec<ScalarBytes>,
+) -> bool {
+    verify_proof(env, vk, proof, public_inputs).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// Batch verification
+// ---------------------------------------------------------------------------
+
+/// Verify `n` proofs against one verifying key with `n + 3` pairings instead of
+/// `4n`.
+///
+/// # Construction
+///
+/// Each proof satisfies `e(−A_i, B_i)·e(α, β)·e(L_i, γ)·e(C_i, δ) = 1`. Raising
+/// proof `i`'s equation to a random `r_i` and multiplying them together gives
+///
+/// ```text
+/// ∏_i e(−r_i·A_i, B_i) · e((Σ r_i)·α, β) · e(Σ r_i·L_i, γ) · e(Σ r_i·C_i, δ) = 1
+/// ```
+///
+/// because α, β, γ and δ are shared. If any single proof is invalid, the
+/// product is `1` only for a vanishing fraction of coefficient vectors, so a
+/// forger who cannot predict `r` cannot pass.
+///
+/// # Why the coefficients come from a transcript
+///
+/// `env.prng()` is seeded from ledger state a submitter can observe, and the
+/// submitter chooses when to submit. Deriving `r_i` by hashing the entire batch
+/// (every proof point and every public input, in order) removes that freedom:
+/// changing anything to game the coefficients changes the coefficients.
+///
+/// # The nested-MSM fold
+///
+/// `Σ_i r_i·L_i` expands to `Σ_i r_i·(Σ_j x_{i,j}·IC_j)`. Swapping the sums
+/// gives `Σ_j IC_j·(Σ_i r_i·x_{i,j})` — one MSM of width `n_inputs + 1` over
+/// scalar sums, rather than one MSM per proof. For a 16-proof batch of the
+/// 8-input metadata circuit that is 9 scalar multiplications instead of 144.
+pub fn verify_batch(
+    env: &Env,
+    vk: &VerifyingKey,
+    vk_digest: &Digest,
+    proofs: &Vec<Groth16Proof>,
+    inputs: &Vec<Vec<ScalarBytes>>,
+    max_batch: u32,
+) -> Result<(), Error> {
+    let n = proofs.len();
+    if n == 0 {
+        return Err(Error::EmptyBatch);
+    }
+    if n > max_batch {
+        return Err(Error::BatchTooLarge);
+    }
+    if inputs.len() != n {
+        return Err(Error::BatchLengthMismatch);
+    }
+
+    let arity = vk.ic.len();
+    let bls = env.crypto().bls12_381();
+
+    // --- transcript over the whole batch -----------------------------------
+    let mut transcript = Transcript::new(env, BATCH_DST);
+    transcript.absorb_n(vk_digest);
+    transcript.absorb_u32(n);
+    for i in 0..n {
+        let p = proofs.get_unchecked(i);
+        transcript.absorb_n(&p.a);
+        transcript.absorb_n(&p.b);
+        transcript.absorb_n(&p.c);
+        let xs = inputs.get_unchecked(i);
+        if xs.len() + 1 != arity {
+            return Err(Error::PublicInputCountMismatch);
+        }
+        transcript.absorb_u32(xs.len());
+        for j in 0..xs.len() {
+            transcript.absorb_n(&xs.get_unchecked(j));
+        }
+    }
+
+    // --- accumulators -------------------------------------------------------
+    let mut pair_g1: Vec<G1Affine> = Vec::new(env);
+    let mut pair_g2: Vec<G2Affine> = Vec::new(env);
+
+    // Folded IC coefficients: index 0 is the constant term.
+    let mut ic_coeffs: Vec<Fr> = Vec::new(env);
+    for _ in 0..arity {
+        ic_coeffs.push_back(scalar_zero(env));
+    }
+
+    let mut c_bases: Vec<G1Affine> = Vec::new(env);
+    let mut c_scalars: Vec<Fr> = Vec::new(env);
+    let mut alpha_coeff = scalar_zero(env);
+
+    for i in 0..n {
+        let proof = proofs.get_unchecked(i);
+        let r = transcript.challenge(i);
+
+        let a = decode_g1(env, &proof.a, false)?;
+        let b = decode_g2(env, &proof.b, false)?;
+        let c = decode_g1(env, &proof.c, false)?;
+
+        // e(−r_i·A_i, B_i)
+        pair_g1.push_back(-bls.g1_mul(&a, &r));
+        pair_g2.push_back(b);
+
+        // Σ r_i·C_i, deferred into one MSM.
+        c_bases.push_back(c);
+        c_scalars.push_back(r.clone());
+
+        // Σ r_i, the α coefficient.
+        alpha_coeff = bls.fr_add(&alpha_coeff, &r);
+
+        // Fold this proof's public inputs into the shared IC coefficients.
+        let xs = inputs.get_unchecked(i);
+        let c0 = ic_coeffs.get_unchecked(0);
+        ic_coeffs.set(0, bls.fr_add(&c0, &r));
+        for j in 0..xs.len() {
+            let x = checked_scalar(&xs.get_unchecked(j))?;
+            let term = bls.fr_mul(&r, &x);
+            let prev = ic_coeffs.get_unchecked(j + 1);
+            ic_coeffs.set(j + 1, bls.fr_add(&prev, &term));
+        }
+    }
+
+    // Σ r_i·L_i as a single MSM over the IC bases.
+    let mut ic_bases: Vec<G1Affine> = Vec::new(env);
+    for j in 0..arity {
+        ic_bases.push_back(G1Affine::from_bytes(vk.ic.get_unchecked(j)));
+    }
+    let folded_l = bls.g1_msm(ic_bases, ic_coeffs);
+
+    // e((Σ r_i)·α, β)
+    let alpha = G1Affine::from_bytes(vk.alpha_g1.clone());
+    pair_g1.push_back(bls.g1_mul(&alpha, &alpha_coeff));
+    pair_g2.push_back(G2Affine::from_bytes(vk.beta_g2.clone()));
+
+    // e(Σ r_i·L_i, γ)
+    pair_g1.push_back(folded_l);
+    pair_g2.push_back(G2Affine::from_bytes(vk.gamma_g2.clone()));
+
+    // e(Σ r_i·C_i, δ)
+    pair_g1.push_back(bls.g1_msm(c_bases, c_scalars));
+    pair_g2.push_back(G2Affine::from_bytes(vk.delta_g2.clone()));
+
+    if bls.pairing_check(pair_g1, pair_g2) {
+        Ok(())
+    } else {
+        Err(Error::BatchVerificationFailed)
+    }
+}
+
+/// Identify which members of a failed batch are individually invalid.
+///
+/// Only worth calling after [`verify_batch`] has already failed — it costs a
+/// full `4n` pairings. Exposed so a caller can attribute blame (and charge the
+/// right submitter) rather than rejecting an entire batch opaquely.
+pub fn locate_batch_failures(
+    env: &Env,
+    vk: &VerifyingKey,
+    proofs: &Vec<Groth16Proof>,
+    inputs: &Vec<Vec<ScalarBytes>>,
+) -> Vec<u32> {
+    let mut failed: Vec<u32> = Vec::new(env);
+    let n = proofs.len();
+    for i in 0..n {
+        let proof = proofs.get_unchecked(i);
+        let xs = inputs.get_unchecked(i);
+        if verify_proof(env, vk, &proof, &xs).is_err() {
+            failed.push_back(i);
+        }
+    }
+    failed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{BytesN, Env};
+
+    fn g1_infinity(env: &Env) -> G1Bytes {
+        let mut buf = [0u8; 96];
+        buf[0] = FLAG_INFINITY;
+        BytesN::from_array(env, &buf)
+    }
+
+    fn g2_infinity(env: &Env) -> G2Bytes {
+        let mut buf = [0u8; 192];
+        buf[0] = FLAG_INFINITY;
+        BytesN::from_array(env, &buf)
+    }
+
+    #[test]
+    fn infinity_encoding_is_wellformed() {
+        let env = Env::default();
+        assert!(g1_wellformed(&g1_infinity(&env)).is_ok());
+        assert!(g2_wellformed(&g2_infinity(&env)).is_ok());
+    }
+
+    #[test]
+    fn infinity_with_dirty_payload_is_rejected() {
+        let env = Env::default();
+        let mut buf = [0u8; 96];
+        buf[0] = FLAG_INFINITY;
+        buf[50] = 1;
+        assert_eq!(
+            g1_wellformed(&BytesN::from_array(&env, &buf)),
+            Err(Error::InvalidG1Point)
+        );
+    }
+
+    #[test]
+    fn compression_flag_is_rejected() {
+        let env = Env::default();
+        let mut buf = [0u8; 96];
+        buf[0] = FLAG_COMPRESSION;
+        assert_eq!(
+            g1_wellformed(&BytesN::from_array(&env, &buf)),
+            Err(Error::InvalidG1Point)
+        );
+    }
+
+    #[test]
+    fn sort_flag_is_rejected() {
+        let env = Env::default();
+        let mut buf = [0u8; 192];
+        buf[0] = FLAG_SORT;
+        assert_eq!(
+            g2_wellformed(&BytesN::from_array(&env, &buf)),
+            Err(Error::InvalidG2Point)
+        );
+    }
+
+    #[test]
+    fn out_of_range_coordinate_is_rejected() {
+        let env = Env::default();
+        let buf = [0xffu8; 96];
+        assert_eq!(
+            g1_wellformed(&BytesN::from_array(&env, &buf)),
+            Err(Error::InvalidG1Point)
+        );
+    }
+
+    #[test]
+    fn modulus_minus_one_coordinate_is_in_range() {
+        let mut limb = FP_MODULUS_BE;
+        limb[47] -= 1;
+        assert!(fp_in_range(&limb, false));
+    }
+
+    #[test]
+    fn modulus_coordinate_is_out_of_range() {
+        assert!(!fp_in_range(&FP_MODULUS_BE, false));
+    }
+
+    #[test]
+    fn decode_rejects_infinity_when_disallowed() {
+        let env = Env::default();
+        assert_eq!(
+            decode_g1(&env, &g1_infinity(&env), false),
+            Err(Error::PointAtInfinity)
+        );
+        assert_eq!(
+            decode_g2(&env, &g2_infinity(&env), false),
+            Err(Error::PointAtInfinity)
+        );
+    }
+
+    #[test]
+    fn decode_accepts_infinity_when_allowed() {
+        let env = Env::default();
+        assert!(decode_g1(&env, &g1_infinity(&env), true).is_ok());
+    }
+}

--- a/contracts/zk_metadata_verifier/src/lib.rs
+++ b/contracts/zk_metadata_verifier/src/lib.rs
@@ -1,0 +1,100 @@
+#![no_std]
+//! # SoroMint ZK Metadata Verifier
+//!
+//! On-chain Groth16 verification of off-chain AI metadata safety proofs.
+//!
+//! ## Why this exists
+//!
+//! The predecessor contract (`ai_metadata_validator`) evaluated token metadata
+//! directly on chain: regex-ish scanning, substring search against a blocklist,
+//! character-class tallies, heuristic scoring. Every one of those is linear in
+//! the length of a caller-supplied string, executed inside a metered VM, and
+//! the *entire rule set has to be public in contract storage* for it to run.
+//! That design is expensive, it caps out well below anything resembling real
+//! safety screening, and publishing the blocklist hands evasion instructions to
+//! exactly the people it is meant to stop.
+//!
+//! Moving the computation off chain and verifying a proof of it fixes all
+//! three at once. The classifier can be arbitrarily complex — its cost lands on
+//! the prover, not the ledger. The rules stay private behind a Merkle
+//! commitment. And on-chain cost becomes constant: four pairings, regardless of
+//! whether the circuit checked ten rules or ten thousand.
+//!
+//! ## Architecture
+//!
+//! ```text
+//!   off chain                          │  on chain
+//!   ─────────────────────────────────  │  ────────────────────────────────
+//!   metadata payload                   │
+//!        │                             │
+//!        ├─► AI classifier ──► score   │
+//!        │                             │
+//!        ├─► witness builder           │
+//!        │        │                    │
+//!        │        ▼                    │
+//!        │   metadata_validator.circom │
+//!        │        │                    │
+//!        │        ▼                    │
+//!        └─► Groth16 prover ──proof──► │  ZkMetadataVerifier
+//!                                      │      ├─ policy checks   (cheap)
+//!                                      │      ├─ nullifier check (cheap)
+//!                                      │      ├─ pairing check   (≈4 pairings)
+//!                                      │      └─ Attestation ──┐
+//!                                      │                       ▼
+//!                                      │              ZkMintGateway
+//!                                      │              ├─ create_token
+//!                                      │              └─ mint
+//! ```
+//!
+//! ## Module map
+//!
+//! | Module              | Responsibility |
+//! |---------------------|----------------|
+//! | [`groth16`]         | Pairing verification, point decoding, batch folding |
+//! | [`field`]           | Scalar canonicality, Fiat–Shamir transcript |
+//! | [`registry`]        | Verifying keys and timelocked rotation |
+//! | [`policy`]          | Safety thresholds and public-signal semantics |
+//! | [`attestation`]     | Nullifiers and verification receipts |
+//! | [`access`]          | Role-based control |
+//! | [`storage`]         | Keys, durability tiers, TTLs |
+//! | [`contract`]        | The entrypoints |
+//!
+//! ## Trust assumptions
+//!
+//! 1. **Trusted setup.** Groth16 needs a per-circuit CRS. A participant who
+//!    retains the toxic waste can forge proofs for that circuit. The registry's
+//!    published VK digests and rotation timelock exist so that a ceremony can
+//!    be audited and a suspect key replaced under observation.
+//! 2. **Model commitment.** The contract enforces that the prover used the
+//!    committed model, not that the committed model is *good*. Model quality is
+//!    a governance question, tracked through `Policy::version`.
+//! 3. **Issuer binding.** A proof is bound to one issuer address. It says
+//!    nothing about who *generated* it, only who may redeem it.
+
+// `std` is linked for tests only. The wasm build stays allocator-free: nothing
+// in the contract path needs a heap, and pulling one in would add code size to
+// every deployment for the benefit of the test fixtures alone.
+#[cfg(test)]
+extern crate std;
+
+pub mod access;
+pub mod attestation;
+pub mod contract;
+pub mod errors;
+pub mod events;
+pub mod field;
+pub mod groth16;
+pub mod policy;
+pub mod registry;
+pub mod storage;
+pub mod types;
+
+pub use contract::{ZkMetadataVerifier, ZkMetadataVerifierClient};
+pub use errors::Error;
+pub use types::{
+    Attestation, AttestationStatus, BatchOutcome, CircuitRecord, Config, Digest, Groth16Proof,
+    MetadataSignals, PendingRotation, Policy, PolicyParams, Role, ScalarBytes, Stats, VerifyingKey,
+};
+
+#[cfg(test)]
+mod test;

--- a/contracts/zk_metadata_verifier/src/policy.rs
+++ b/contracts/zk_metadata_verifier/src/policy.rs
@@ -1,0 +1,200 @@
+//! AI safety policy management and public-signal semantics.
+//!
+//! # The split between circuit and policy
+//!
+//! The circuit proves a *structural* claim: "I ran the committed scoring
+//! procedure over metadata whose commitment is `C`, against the rule set whose
+//! Merkle root is `R`, using the model committed to by `M`, and it produced
+//! verdict `v` with score `s`."
+//!
+//! It deliberately does **not** hard-code the acceptance threshold. If it did,
+//! every threshold tweak would need a new trusted setup. Instead the contract
+//! holds the thresholds and checks `s <= max_risk_score` in cheap integer
+//! arithmetic, while pinning `R` and `M` so the prover cannot substitute a
+//! weaker rule set or a doctored model.
+//!
+//! That division is what makes the design operable: rules move at governance
+//! speed, the proof system moves at ceremony speed.
+//!
+//! # Public-signal ordering
+//!
+//! [`signals_to_public_inputs`] is the single place the wire order is defined.
+//! It must mirror the circuit's `component main {public [...]}` declaration
+//! exactly — a permutation here would verify proofs of a *different statement*
+//! than the one the contract believes it is checking, with no visible symptom.
+
+use soroban_sdk::{xdr::ToXdr, Address, Env, Vec};
+
+use crate::errors::Error;
+use crate::events;
+use crate::field::{u32_to_scalar_bytes, ISSUER_DST};
+use crate::storage;
+use crate::types::{Digest, MetadataSignals, Policy, PolicyParams, Role, ScalarBytes};
+
+/// Verdict value the circuit emits for "metadata is safe".
+pub const VERDICT_SAFE: u32 = 1;
+
+/// Upper bound on `risk_scale`, keeping score arithmetic well away from `u32`
+/// overflow and matching the circuit's range-check width.
+pub const MAX_RISK_SCALE: u32 = 1_000_000;
+
+/// Publish a new policy version. It is stored but not yet in force.
+pub fn publish_policy(env: &Env, caller: &Address, params: PolicyParams) -> Result<Policy, Error> {
+    crate::access::require_role(env, caller, Role::PolicyAdmin)?;
+    validate_params(env, &params)?;
+
+    // Versions must strictly increase so that an attestation's recorded
+    // `policy_version` is a total order — auditors can then say "everything
+    // attested under v3 or earlier is suspect" without ambiguity.
+    if let Ok(active) = storage::active_policy_version(env) {
+        if params.version <= active {
+            return Err(Error::PolicyVersionRegression);
+        }
+    }
+
+    let policy = Policy {
+        version: params.version,
+        policy_root: params.policy_root.clone(),
+        model_commitment: params.model_commitment,
+        max_risk_score: params.max_risk_score,
+        risk_scale: params.risk_scale,
+        max_validity_ledgers: params.max_validity_ledgers,
+        circuit_id: params.circuit_id,
+        activated_at: 0,
+        rulebook_uri: params.rulebook_uri,
+    };
+
+    storage::set_policy(env, &policy);
+    storage::push_policy_index(env, policy.version);
+    events::policy_published(env, policy.version, &params.policy_root, caller);
+
+    Ok(policy)
+}
+
+/// Put a published policy into force.
+pub fn activate_policy(env: &Env, caller: &Address, version: u32) -> Result<Policy, Error> {
+    crate::access::require_role(env, caller, Role::PolicyAdmin)?;
+
+    let mut policy = storage::get_policy(env, version)?;
+    // The policy names the circuit its proofs must satisfy; activating a policy
+    // that points at a missing or disabled circuit would brick verification.
+    crate::registry::active_circuit(env, &policy.circuit_id)?;
+
+    let previous = storage::active_policy_version(env).unwrap_or(0);
+    if version <= previous {
+        return Err(Error::PolicyVersionRegression);
+    }
+
+    policy.activated_at = env.ledger().sequence();
+    storage::set_policy(env, &policy);
+    storage::set_active_policy_version(env, version);
+    events::policy_activated(env, version, previous, caller);
+
+    Ok(policy)
+}
+
+/// Reject structurally nonsensical policy parameters at publish time, where the
+/// error is cheap, rather than at verification time where it is confusing.
+fn validate_params(env: &Env, params: &PolicyParams) -> Result<(), Error> {
+    if params.version == 0 {
+        return Err(Error::InvalidPolicyParameters);
+    }
+    if params.risk_scale == 0 || params.risk_scale > MAX_RISK_SCALE {
+        return Err(Error::InvalidPolicyParameters);
+    }
+    if params.max_risk_score > params.risk_scale {
+        return Err(Error::InvalidPolicyParameters);
+    }
+    if params.max_validity_ledgers == 0 {
+        return Err(Error::InvalidPolicyParameters);
+    }
+    // A proof must not outlive the nullifier that prevents its replay.
+    let config = storage::get_config(env)?;
+    if params.max_validity_ledgers >= config.nullifier_ttl {
+        return Err(Error::InvalidPolicyParameters);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Signal encoding
+// ---------------------------------------------------------------------------
+
+/// Flatten [`MetadataSignals`] into the circuit's public-input vector.
+///
+/// **Order is load-bearing.** See the module docs.
+pub fn signals_to_public_inputs(env: &Env, signals: &MetadataSignals) -> Vec<ScalarBytes> {
+    let mut inputs: Vec<ScalarBytes> = Vec::new(env);
+    inputs.push_back(u32_to_scalar_bytes(env, signals.verdict)); //            0
+    inputs.push_back(u32_to_scalar_bytes(env, signals.risk_score)); //         1
+    inputs.push_back(signals.policy_root.clone()); //                          2
+    inputs.push_back(signals.model_commitment.clone()); //                     3
+    inputs.push_back(signals.metadata_commitment.clone()); //                  4
+    inputs.push_back(signals.issuer_hash.clone()); //                          5
+    inputs.push_back(signals.nullifier.clone()); //                            6
+    inputs.push_back(u32_to_scalar_bytes(env, signals.expiry_ledger)); //      7
+    inputs
+}
+
+/// Number of public inputs the metadata circuit exposes.
+pub const METADATA_ARITY: u32 = 8;
+
+/// Bind an issuer address to the field element the circuit committed to.
+///
+/// The circuit cannot parse a Stellar address, so the prover feeds it a hash.
+/// The contract recomputes that hash from the *authenticated caller* and
+/// requires equality — which is what stops Mallory from replaying Alice's
+/// perfectly valid proof under her own account.
+///
+/// The top byte is cleared for the same reason as in
+/// [`crate::field::Transcript::challenge`]: the result must be a canonical
+/// field element, and truncation is the cheapest way to guarantee it.
+pub fn issuer_hash(env: &Env, issuer: &Address) -> Digest {
+    let mut buf = soroban_sdk::Bytes::new(env);
+    buf.extend_from_slice(ISSUER_DST);
+    buf.append(&issuer.clone().to_xdr(env));
+    let digest = env.crypto().sha256(&buf);
+    let mut arr = digest.to_array();
+    arr[0] = 0;
+    soroban_sdk::BytesN::from_array(env, &arr)
+}
+
+/// Enforce every policy-level condition on a set of public signals.
+///
+/// Runs *before* the pairing check. Two reasons for the ordering: a mismatched
+/// policy root is a 300-instruction comparison while the pairing is millions,
+/// so failing fast is much cheaper; and it keeps the expensive path from being
+/// a free denial-of-service amplifier.
+pub fn check_signals(
+    env: &Env,
+    policy: &Policy,
+    signals: &MetadataSignals,
+    issuer: &Address,
+) -> Result<(), Error> {
+    if signals.verdict != VERDICT_SAFE {
+        return Err(Error::VerdictRejected);
+    }
+    if signals.policy_root != policy.policy_root {
+        return Err(Error::PolicyRootMismatch);
+    }
+    if signals.model_commitment != policy.model_commitment {
+        return Err(Error::ModelCommitmentMismatch);
+    }
+    if signals.risk_score > policy.max_risk_score {
+        return Err(Error::RiskScoreTooHigh);
+    }
+
+    let now = env.ledger().sequence();
+    if signals.expiry_ledger <= now {
+        return Err(Error::ProofExpired);
+    }
+    if signals.expiry_ledger.saturating_sub(now) > policy.max_validity_ledgers {
+        return Err(Error::ExpiryTooDistant);
+    }
+
+    if signals.issuer_hash != issuer_hash(env, issuer) {
+        return Err(Error::IssuerBindingMismatch);
+    }
+
+    Ok(())
+}

--- a/contracts/zk_metadata_verifier/src/registry.rs
+++ b/contracts/zk_metadata_verifier/src/registry.rs
@@ -1,0 +1,195 @@
+//! Verifying-key registry with timelocked rotation.
+//!
+//! A Groth16 verifying key is the entire trust anchor of the system: whoever
+//! controls it decides what statements are provable. Swapping it must therefore
+//! be *observable before it takes effect*, which is what the two-phase
+//! propose/finalize flow buys. Between `propose_rotation` and
+//! `finalize_rotation` the incoming key's digest is public on chain, giving
+//! integrators a window to compare it against the key produced by the trusted
+//! setup ceremony and to exit if it does not match.
+//!
+//! `freeze_circuit` is the terminal state: once frozen, a circuit's key can
+//! never change again. That is the right end state for a circuit whose
+//! ceremony transcript has been independently verified.
+
+use soroban_sdk::{Address, Env, String, Symbol};
+
+use crate::errors::Error;
+use crate::events;
+use crate::groth16::{validate_verifying_key, verifying_key_digest};
+use crate::storage;
+use crate::types::{CircuitRecord, PendingRotation, Role, VerifyingKey};
+
+/// Register a brand-new circuit.
+pub fn register_circuit(
+    env: &Env,
+    caller: &Address,
+    circuit_id: Symbol,
+    vk: VerifyingKey,
+    num_public_inputs: u32,
+    provenance: String,
+) -> Result<CircuitRecord, Error> {
+    crate::access::require_role(env, caller, Role::CircuitAdmin)?;
+
+    if storage::has_circuit(env, &circuit_id) {
+        return Err(Error::CircuitAlreadyExists);
+    }
+
+    validate_verifying_key(env, &vk, num_public_inputs)?;
+    let vk_digest = verifying_key_digest(env, &vk, num_public_inputs);
+
+    let record = CircuitRecord {
+        circuit_id: circuit_id.clone(),
+        vk,
+        num_public_inputs,
+        vk_digest: vk_digest.clone(),
+        provenance,
+        enabled: true,
+        frozen: false,
+        revision: 0,
+        activated_at: env.ledger().sequence(),
+        verifications: 0,
+    };
+
+    storage::set_circuit(env, &record);
+    storage::push_circuit_index(env, &circuit_id);
+    events::circuit_registered(env, &circuit_id, &vk_digest, num_public_inputs, caller);
+
+    Ok(record)
+}
+
+/// Queue a replacement key. Takes effect no earlier than `now + timelock`.
+pub fn propose_rotation(
+    env: &Env,
+    caller: &Address,
+    circuit_id: Symbol,
+    vk: VerifyingKey,
+    num_public_inputs: u32,
+) -> Result<PendingRotation, Error> {
+    crate::access::require_role(env, caller, Role::CircuitAdmin)?;
+
+    let record = storage::get_circuit(env, &circuit_id)?;
+    if record.frozen {
+        return Err(Error::CircuitFrozen);
+    }
+
+    validate_verifying_key(env, &vk, num_public_inputs)?;
+    let vk_digest = verifying_key_digest(env, &vk, num_public_inputs);
+    if vk_digest == record.vk_digest {
+        return Err(Error::VerifyingKeyUnchanged);
+    }
+
+    let config = storage::get_config(env)?;
+    let eta = env
+        .ledger()
+        .sequence()
+        .saturating_add(config.rotation_timelock);
+
+    let rotation = PendingRotation {
+        circuit_id: circuit_id.clone(),
+        vk,
+        num_public_inputs,
+        vk_digest: vk_digest.clone(),
+        eta,
+        proposer: caller.clone(),
+    };
+
+    storage::set_rotation(env, &rotation);
+    events::rotation_proposed(env, &circuit_id, &vk_digest, eta, caller);
+
+    Ok(rotation)
+}
+
+/// Withdraw a queued rotation before it activates.
+pub fn cancel_rotation(env: &Env, caller: &Address, circuit_id: Symbol) -> Result<(), Error> {
+    crate::access::require_role(env, caller, Role::CircuitAdmin)?;
+    // Presence check first so cancelling nothing is an explicit error rather
+    // than a silent success that an operator might mistake for a real cancel.
+    storage::get_rotation(env, &circuit_id)?;
+    storage::clear_rotation(env, &circuit_id);
+    events::rotation_cancelled(env, &circuit_id, caller);
+    Ok(())
+}
+
+/// Activate a queued rotation once its timelock has elapsed.
+pub fn finalize_rotation(
+    env: &Env,
+    caller: &Address,
+    circuit_id: Symbol,
+) -> Result<CircuitRecord, Error> {
+    crate::access::require_role(env, caller, Role::CircuitAdmin)?;
+
+    let rotation = storage::get_rotation(env, &circuit_id)?;
+    if env.ledger().sequence() < rotation.eta {
+        return Err(Error::RotationTimelockActive);
+    }
+
+    let mut record = storage::get_circuit(env, &circuit_id)?;
+    if record.frozen {
+        return Err(Error::CircuitFrozen);
+    }
+
+    let old_digest = record.vk_digest.clone();
+    record.vk = rotation.vk;
+    record.num_public_inputs = rotation.num_public_inputs;
+    record.vk_digest = rotation.vk_digest.clone();
+    record.revision = record.revision.saturating_add(1);
+    record.activated_at = env.ledger().sequence();
+
+    storage::set_circuit(env, &record);
+    storage::clear_rotation(env, &circuit_id);
+    events::rotation_finalized(
+        env,
+        &circuit_id,
+        &old_digest,
+        &record.vk_digest,
+        record.revision,
+    );
+
+    Ok(record)
+}
+
+/// Enable or disable a circuit without touching its key.
+///
+/// The escape hatch for "we found a bug in the circuit at 3am": disabling stops
+/// new proofs immediately, without needing a replacement key ready.
+pub fn set_circuit_enabled(
+    env: &Env,
+    caller: &Address,
+    circuit_id: Symbol,
+    enabled: bool,
+) -> Result<(), Error> {
+    crate::access::require_role(env, caller, Role::CircuitAdmin)?;
+    let mut record = storage::get_circuit(env, &circuit_id)?;
+    record.enabled = enabled;
+    storage::set_circuit(env, &record);
+    events::circuit_enabled(env, &circuit_id, enabled, caller);
+    Ok(())
+}
+
+/// Permanently seal a circuit's verifying key.
+pub fn freeze_circuit(env: &Env, caller: &Address, circuit_id: Symbol) -> Result<(), Error> {
+    crate::access::require_admin(env, caller)?;
+    let mut record = storage::get_circuit(env, &circuit_id)?;
+    record.frozen = true;
+    storage::set_circuit(env, &record);
+    // A queued rotation would otherwise sit there looking finalizable.
+    storage::clear_rotation(env, &circuit_id);
+    events::circuit_frozen(env, &circuit_id, caller);
+    Ok(())
+}
+
+/// Fetch a circuit that is registered *and* usable for verification.
+pub fn active_circuit(env: &Env, circuit_id: &Symbol) -> Result<CircuitRecord, Error> {
+    let record = storage::get_circuit(env, circuit_id)?;
+    if !record.enabled {
+        return Err(Error::CircuitDisabled);
+    }
+    Ok(record)
+}
+
+/// Record a successful verification against a circuit.
+pub fn note_verification(env: &Env, record: &mut CircuitRecord) {
+    record.verifications = record.verifications.saturating_add(1);
+    storage::set_circuit(env, record);
+}

--- a/contracts/zk_metadata_verifier/src/storage.rs
+++ b/contracts/zk_metadata_verifier/src/storage.rs
@@ -1,0 +1,394 @@
+//! Storage layout and TTL management.
+//!
+//! # Durability tiers
+//!
+//! | Tier         | Holds                                        | Rationale |
+//! |--------------|----------------------------------------------|-----------|
+//! | Instance     | config, roles, stats, active policy pointer  | Small, read on nearly every call, must live as long as the contract. |
+//! | Persistent   | circuits, policies, attestations, nullifiers | Must survive independently; losing a nullifier would re-open a replay window. |
+//! | Temporary    | *(unused)*                                   | Deliberately avoided — see below. |
+//!
+//! Nullifiers are the subtle case. It is tempting to store them as temporary
+//! entries so they expire cheaply, but a temporary entry that expires *before*
+//! the proof it nullifies does re-opens exactly the replay the nullifier
+//! exists to prevent. They therefore live in persistent storage with a TTL that
+//! [`crate::types::Config`] forces to exceed the maximum proof validity window.
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+use crate::errors::Error;
+use crate::types::{
+    Attestation, CircuitRecord, Config, Digest, PendingRotation, Policy, Role, Stats,
+};
+
+/// Instance-storage entries live as long as the contract itself.
+pub const INSTANCE_BUMP_AMOUNT: u32 = 518_400; // ~30 days at 5s ledgers
+pub const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - 86_400;
+
+/// Circuits and policies are long-lived governance state.
+pub const REGISTRY_BUMP_AMOUNT: u32 = 1_036_800; // ~60 days
+pub const REGISTRY_LIFETIME_THRESHOLD: u32 = REGISTRY_BUMP_AMOUNT - 172_800;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Marker written by `initialize`.
+    Initialized,
+    /// [`Config`].
+    Config,
+    /// Paused flag.
+    Paused,
+    /// [`Stats`].
+    Stats,
+    /// Root administrator address.
+    Admin,
+    /// Address awaiting a two-step admin handoff.
+    PendingAdmin,
+    /// `(Role, Address) -> bool` grant.
+    RoleGrant(Role, Address),
+    /// Number of holders of a role, so the last admin cannot be removed.
+    RoleCount(Role),
+    /// `Symbol -> CircuitRecord`.
+    Circuit(Symbol),
+    /// Ordered list of registered circuit ids.
+    CircuitIndex,
+    /// `Symbol -> PendingRotation`.
+    Rotation(Symbol),
+    /// `u32 -> Policy`.
+    Policy(u32),
+    /// Version number of the policy currently in force.
+    ActivePolicy,
+    /// Ordered list of published policy versions.
+    PolicyIndex,
+    /// `Digest -> u32` (ledger at which the nullifier was spent).
+    Nullifier(Digest),
+    /// `Digest -> Attestation`, keyed by metadata commitment.
+    Attestation(Digest),
+    /// Per-issuer count of attestations issued, for rate observation.
+    IssuerCount(Address),
+}
+
+// ---------------------------------------------------------------------------
+// Instance helpers
+// ---------------------------------------------------------------------------
+
+/// Extend the instance TTL. Called at the top of every state-mutating entry.
+pub fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Initialized)
+}
+
+pub fn mark_initialized(env: &Env) {
+    env.storage().instance().set(&DataKey::Initialized, &true);
+}
+
+pub fn require_initialized(env: &Env) -> Result<(), Error> {
+    if is_initialized(env) {
+        Ok(())
+    } else {
+        Err(Error::NotInitialized)
+    }
+}
+
+pub fn get_config(env: &Env) -> Result<Config, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)
+}
+
+pub fn set_config(env: &Env, config: &Config) {
+    env.storage().instance().set(&DataKey::Config, config);
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&DataKey::Paused, &paused);
+}
+
+pub fn require_not_paused(env: &Env) -> Result<(), Error> {
+    if is_paused(env) {
+        Err(Error::Paused)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn get_stats(env: &Env) -> Stats {
+    env.storage()
+        .instance()
+        .get(&DataKey::Stats)
+        .unwrap_or_default()
+}
+
+pub fn set_stats(env: &Env, stats: &Stats) {
+    env.storage().instance().set(&DataKey::Stats, stats);
+}
+
+/// Apply a mutation to [`Stats`] and write it back.
+pub fn with_stats<F: FnOnce(&mut Stats)>(env: &Env, f: F) {
+    let mut stats = get_stats(env);
+    f(&mut stats);
+    set_stats(env, &stats);
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+pub fn get_admin(env: &Env) -> Result<Address, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_pending_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::PendingAdmin)
+}
+
+pub fn set_pending_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::PendingAdmin, admin);
+}
+
+pub fn clear_pending_admin(env: &Env) {
+    env.storage().instance().remove(&DataKey::PendingAdmin);
+}
+
+pub fn has_role(env: &Env, role: Role, who: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::RoleGrant(role, who.clone()))
+        .unwrap_or(false)
+}
+
+pub fn grant_role(env: &Env, role: Role, who: &Address) {
+    if has_role(env, role, who) {
+        return;
+    }
+    env.storage()
+        .instance()
+        .set(&DataKey::RoleGrant(role, who.clone()), &true);
+    let count: u32 = role_count(env, role);
+    env.storage()
+        .instance()
+        .set(&DataKey::RoleCount(role), &(count + 1));
+}
+
+pub fn revoke_role(env: &Env, role: Role, who: &Address) {
+    if !has_role(env, role, who) {
+        return;
+    }
+    env.storage()
+        .instance()
+        .remove(&DataKey::RoleGrant(role, who.clone()));
+    let count: u32 = role_count(env, role);
+    env.storage()
+        .instance()
+        .set(&DataKey::RoleCount(role), &count.saturating_sub(1));
+}
+
+pub fn role_count(env: &Env, role: Role) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::RoleCount(role))
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Circuits
+// ---------------------------------------------------------------------------
+
+pub fn get_circuit(env: &Env, circuit_id: &Symbol) -> Result<CircuitRecord, Error> {
+    let record: CircuitRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Circuit(circuit_id.clone()))
+        .ok_or(Error::CircuitNotFound)?;
+    env.storage().persistent().extend_ttl(
+        &DataKey::Circuit(circuit_id.clone()),
+        REGISTRY_LIFETIME_THRESHOLD,
+        REGISTRY_BUMP_AMOUNT,
+    );
+    Ok(record)
+}
+
+pub fn has_circuit(env: &Env, circuit_id: &Symbol) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::Circuit(circuit_id.clone()))
+}
+
+pub fn set_circuit(env: &Env, record: &CircuitRecord) {
+    let key = DataKey::Circuit(record.circuit_id.clone());
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, REGISTRY_LIFETIME_THRESHOLD, REGISTRY_BUMP_AMOUNT);
+}
+
+pub fn circuit_index(env: &Env) -> Vec<Symbol> {
+    env.storage()
+        .instance()
+        .get(&DataKey::CircuitIndex)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn push_circuit_index(env: &Env, circuit_id: &Symbol) {
+    let mut index = circuit_index(env);
+    index.push_back(circuit_id.clone());
+    env.storage().instance().set(&DataKey::CircuitIndex, &index);
+}
+
+pub fn get_rotation(env: &Env, circuit_id: &Symbol) -> Result<PendingRotation, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Rotation(circuit_id.clone()))
+        .ok_or(Error::NoPendingRotation)
+}
+
+pub fn set_rotation(env: &Env, rotation: &PendingRotation) {
+    let key = DataKey::Rotation(rotation.circuit_id.clone());
+    env.storage().persistent().set(&key, rotation);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, REGISTRY_LIFETIME_THRESHOLD, REGISTRY_BUMP_AMOUNT);
+}
+
+pub fn clear_rotation(env: &Env, circuit_id: &Symbol) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Rotation(circuit_id.clone()));
+}
+
+// ---------------------------------------------------------------------------
+// Policies
+// ---------------------------------------------------------------------------
+
+pub fn get_policy(env: &Env, version: u32) -> Result<Policy, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Policy(version))
+        .ok_or(Error::PolicyNotFound)
+}
+
+pub fn set_policy(env: &Env, policy: &Policy) {
+    let key = DataKey::Policy(policy.version);
+    env.storage().persistent().set(&key, policy);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, REGISTRY_LIFETIME_THRESHOLD, REGISTRY_BUMP_AMOUNT);
+}
+
+pub fn active_policy_version(env: &Env) -> Result<u32, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ActivePolicy)
+        .ok_or(Error::PolicyNotFound)
+}
+
+pub fn set_active_policy_version(env: &Env, version: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ActivePolicy, &version);
+}
+
+pub fn active_policy(env: &Env) -> Result<Policy, Error> {
+    let version = active_policy_version(env)?;
+    get_policy(env, version)
+}
+
+pub fn policy_index(env: &Env) -> Vec<u32> {
+    env.storage()
+        .instance()
+        .get(&DataKey::PolicyIndex)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn push_policy_index(env: &Env, version: u32) {
+    let mut index = policy_index(env);
+    index.push_back(version);
+    env.storage().instance().set(&DataKey::PolicyIndex, &index);
+}
+
+// ---------------------------------------------------------------------------
+// Nullifiers
+// ---------------------------------------------------------------------------
+
+pub fn nullifier_spent_at(env: &Env, nullifier: &Digest) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Nullifier(nullifier.clone()))
+}
+
+pub fn spend_nullifier(env: &Env, nullifier: &Digest, ttl: u32) {
+    let key = DataKey::Nullifier(nullifier.clone());
+    env.storage()
+        .persistent()
+        .set(&key, &env.ledger().sequence());
+    let threshold = ttl.saturating_sub(ttl / 8).max(1);
+    env.storage().persistent().extend_ttl(&key, threshold, ttl);
+}
+
+// ---------------------------------------------------------------------------
+// Attestations
+// ---------------------------------------------------------------------------
+
+pub fn get_attestation(env: &Env, commitment: &Digest) -> Result<Attestation, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Attestation(commitment.clone()))
+        .ok_or(Error::AttestationNotFound)
+}
+
+pub fn find_attestation(env: &Env, commitment: &Digest) -> Option<Attestation> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Attestation(commitment.clone()))
+}
+
+pub fn set_attestation(env: &Env, attestation: &Attestation, ttl: u32) {
+    let key = DataKey::Attestation(attestation.metadata_commitment.clone());
+    env.storage().persistent().set(&key, attestation);
+    let threshold = ttl.saturating_sub(ttl / 8).max(1);
+    env.storage().persistent().extend_ttl(&key, threshold, ttl);
+}
+
+pub fn remove_attestation(env: &Env, commitment: &Digest) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Attestation(commitment.clone()));
+}
+
+pub fn bump_issuer_count(env: &Env, issuer: &Address) -> u64 {
+    let key = DataKey::IssuerCount(issuer.clone());
+    let count: u64 = env.storage().persistent().get(&key).unwrap_or(0);
+    let next = count.saturating_add(1);
+    env.storage().persistent().set(&key, &next);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, REGISTRY_LIFETIME_THRESHOLD, REGISTRY_BUMP_AMOUNT);
+    next
+}
+
+pub fn issuer_count(env: &Env, issuer: &Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::IssuerCount(issuer.clone()))
+        .unwrap_or(0)
+}

--- a/contracts/zk_metadata_verifier/src/test/access_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/access_tests.rs
@@ -1,0 +1,266 @@
+//! Access control, pausing, configuration, and cost measurement.
+
+use soroban_sdk::{testutils::Address as _, Address};
+
+use super::{scenario, setup};
+use crate::errors::Error;
+use crate::types::Role;
+
+#[test]
+fn double_initialize_is_rejected() {
+    let h = setup();
+    let err = h.client.try_initialize(&h.admin).err().unwrap().unwrap();
+    assert_eq!(err, Error::AlreadyInitialized);
+}
+
+#[test]
+fn admin_holds_every_role_implicitly() {
+    let h = setup();
+    assert!(h.client.has_role(&Role::PolicyAdmin, &h.admin));
+    assert!(h.client.has_role(&Role::CircuitAdmin, &h.admin));
+    assert!(h.client.has_role(&Role::Pauser, &h.admin));
+}
+
+#[test]
+fn grant_and_revoke_round_trip() {
+    let h = setup();
+    let who = Address::generate(&h.env);
+    assert!(!h.client.has_role(&Role::Pauser, &who));
+
+    h.client.grant_role(&h.admin, &Role::Pauser, &who);
+    assert!(h.client.has_role(&Role::Pauser, &who));
+
+    h.client.revoke_role(&h.admin, &Role::Pauser, &who);
+    assert!(!h.client.has_role(&Role::Pauser, &who));
+}
+
+#[test]
+fn admin_cannot_be_granted_as_a_plain_role() {
+    let h = setup();
+    let who = Address::generate(&h.env);
+    // A second root admin created without a handoff ceremony would bypass the
+    // two-step transfer entirely.
+    let err = h
+        .client
+        .try_grant_role(&h.admin, &Role::Admin, &who)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidRoleTarget);
+}
+
+#[test]
+fn non_admin_cannot_grant() {
+    let h = setup();
+    let stranger = Address::generate(&h.env);
+    let who = Address::generate(&h.env);
+    let err = h
+        .client
+        .try_grant_role(&stranger, &Role::Pauser, &who)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn admin_transfer_is_two_step() {
+    let h = setup();
+    let successor = Address::generate(&h.env);
+
+    h.client.transfer_admin(&h.admin, &successor);
+    // Nomination alone changes nothing.
+    assert_eq!(h.client.get_admin(), h.admin);
+
+    h.client.accept_admin(&successor);
+    assert_eq!(h.client.get_admin(), successor);
+
+    // The old key is now just another address.
+    let err = h
+        .client
+        .try_transfer_admin(&h.admin, &successor)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn only_the_nominee_can_accept() {
+    let h = setup();
+    let successor = Address::generate(&h.env);
+    let impostor = Address::generate(&h.env);
+    h.client.transfer_admin(&h.admin, &successor);
+
+    let err = h.client.try_accept_admin(&impostor).err().unwrap().unwrap();
+    assert_eq!(err, Error::NoPendingTransfer);
+}
+
+#[test]
+fn accepting_without_a_nomination_is_rejected() {
+    let h = setup();
+    let who = Address::generate(&h.env);
+    let err = h.client.try_accept_admin(&who).err().unwrap().unwrap();
+    assert_eq!(err, Error::NoPendingTransfer);
+}
+
+#[test]
+fn transfer_can_be_cancelled() {
+    let h = setup();
+    let successor = Address::generate(&h.env);
+    h.client.transfer_admin(&h.admin, &successor);
+    h.client.cancel_admin_transfer(&h.admin);
+
+    let err = h
+        .client
+        .try_accept_admin(&successor)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::NoPendingTransfer);
+}
+
+#[test]
+fn transfer_to_self_is_rejected() {
+    let h = setup();
+    let err = h
+        .client
+        .try_transfer_admin(&h.admin, &h.admin)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidRoleTarget);
+}
+
+#[test]
+fn pauser_can_pause_but_not_unpause() {
+    let h = setup();
+    let responder = Address::generate(&h.env);
+    h.client.grant_role(&h.admin, &Role::Pauser, &responder);
+
+    h.client.pause(&responder);
+    assert!(h.client.is_paused());
+
+    // Deliberately asymmetric: stopping the system is an emergency action,
+    // restarting it is a considered one.
+    let err = h.client.try_unpause(&responder).err().unwrap().unwrap();
+    assert_eq!(err, Error::Unauthorized);
+
+    h.client.unpause(&h.admin);
+    assert!(!h.client.is_paused());
+}
+
+#[test]
+fn double_pause_is_rejected() {
+    let h = setup();
+    h.client.pause(&h.admin);
+    let err = h.client.try_pause(&h.admin).err().unwrap().unwrap();
+    assert_eq!(err, Error::Paused);
+}
+
+#[test]
+fn unpausing_a_running_contract_is_rejected() {
+    let h = setup();
+    let err = h.client.try_unpause(&h.admin).err().unwrap().unwrap();
+    assert_eq!(err, Error::NotPaused);
+}
+
+#[test]
+fn config_rejects_nullifier_ttl_below_attestation_ttl() {
+    let h = setup();
+    let mut config = h.client.get_config();
+    config.nullifier_ttl = config.attestation_ttl;
+
+    // Same invariant as the policy check, enforced from the other direction.
+    let err = h
+        .client
+        .try_set_config(&h.admin, &config)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidPolicyParameters);
+}
+
+#[test]
+fn config_rejects_zero_batch_size() {
+    let h = setup();
+    let mut config = h.client.get_config();
+    config.max_batch_size = 0;
+    let err = h
+        .client
+        .try_set_config(&h.admin, &config)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::BatchTooLarge);
+}
+
+#[test]
+fn config_rejects_oversized_batch_cap() {
+    let h = setup();
+    let mut config = h.client.get_config();
+    config.max_batch_size = crate::groth16::MAX_BATCH_SIZE + 1;
+    let err = h
+        .client
+        .try_set_config(&h.admin, &config)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::BatchTooLarge);
+}
+
+#[test]
+fn non_admin_cannot_change_config() {
+    let h = setup();
+    let stranger = Address::generate(&h.env);
+    let config = h.client.get_config();
+    let err = h
+        .client
+        .try_set_config(&stranger, &config)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn issuer_auth_can_be_disabled_for_relayed_submission() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+
+    let mut config = s.h.client.get_config();
+    config.require_issuer_auth = false;
+    s.h.client.set_config(&s.h.admin, &config);
+
+    // With auth off, anyone may relay a proof — the issuer binding in the
+    // public signals still decides who the attestation belongs to, so this is
+    // a meter-payer question, not a security one.
+    let signals = s.signals(&issuer, 55);
+    let att =
+        s.h.client
+            .verify_metadata(&issuer, &s.proof(&signals), &signals);
+    assert_eq!(att.issuer, issuer);
+}
+
+/// Measure what a verification actually costs.
+///
+/// Not an assertion about a specific number — those drift with host versions —
+/// but a guard that the figure stays inside the same order of magnitude as a
+/// Soroban transaction budget, and a printout an operator can read.
+#[test]
+fn cost_report() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 60);
+    let proof = s.proof(&signals);
+
+    s.h.env.cost_estimate().budget().reset_default();
+    s.h.client.verify_metadata(&issuer, &proof, &signals);
+
+    let cpu = s.h.env.cost_estimate().budget().cpu_instruction_cost();
+    let mem = s.h.env.cost_estimate().budget().memory_bytes_cost();
+    ::std::println!("verify_metadata: {} cpu insns, {} mem bytes", cpu, mem);
+
+    assert!(cpu > 0);
+    assert!(mem > 0);
+}

--- a/contracts/zk_metadata_verifier/src/test/attestation_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/attestation_tests.rs
@@ -1,0 +1,275 @@
+//! Attestation lifecycle: issuance, consumption, expiry, revocation.
+
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address};
+
+use super::{scenario, START_LEDGER};
+use crate::errors::Error;
+
+#[test]
+fn registered_consumer_can_redeem_once() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+
+    let signals = s.signals(&issuer, 1);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    let consumed =
+        s.h.client
+            .consume_attestation(&gateway, &signals.metadata_commitment, &issuer);
+    assert!(consumed.consumed);
+    assert_eq!(consumed.consumer, Some(gateway.clone()));
+    assert_eq!(consumed.consumed_at, Some(START_LEDGER));
+
+    // Single-use: one safety proof authorizes one token, not a stream of them.
+    let err =
+        s.h.client
+            .try_consume_attestation(&gateway, &signals.metadata_commitment, &issuer)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::AttestationAlreadyConsumed);
+}
+
+#[test]
+fn unregistered_caller_cannot_consume() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let stranger = Address::generate(&s.h.env);
+
+    let signals = s.signals(&issuer, 2);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    let err =
+        s.h.client
+            .try_consume_attestation(&stranger, &signals.metadata_commitment, &issuer)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::NotAuthorizedConsumer);
+}
+
+#[test]
+fn consuming_under_the_wrong_issuer_is_refused() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let other = Address::generate(&s.h.env);
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+
+    let signals = s.signals(&issuer, 3);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    let err =
+        s.h.client
+            .try_consume_attestation(&gateway, &signals.metadata_commitment, &other)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::IssuerBindingMismatch);
+}
+
+#[test]
+fn expired_attestation_cannot_be_consumed() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+
+    let signals = s.signals(&issuer, 4);
+    let att =
+        s.h.client
+            .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    s.h.env
+        .ledger()
+        .with_mut(|l| l.sequence_number = att.expires_at + 1);
+
+    let err =
+        s.h.client
+            .try_consume_attestation(&gateway, &signals.metadata_commitment, &issuer)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::AttestationExpired);
+}
+
+#[test]
+fn attestation_never_outlives_the_proofs_own_expiry() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 5);
+    let att =
+        s.h.client
+            .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    // The retention window is ~7 days and the proof claims ~half a day. An
+    // issuer who proved "safe as of ledger N" has said nothing about later
+    // ledgers, so the shorter bound wins.
+    let config = s.h.client.get_config();
+    assert!(signals.expiry_ledger < START_LEDGER + config.attestation_ttl);
+    assert_eq!(att.expires_at, signals.expiry_ledger);
+}
+
+#[test]
+fn retention_caps_a_long_lived_proof() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+
+    // Shrink retention below the proof's window and re-check which bound binds.
+    let mut config = s.h.client.get_config();
+    config.attestation_ttl = 100;
+    s.h.client.set_config(&s.h.admin, &config);
+
+    let signals = s.signals(&issuer, 6);
+    let att =
+        s.h.client
+            .verify_metadata(&issuer, &s.proof(&signals), &signals);
+    assert_eq!(att.expires_at, START_LEDGER + 100);
+}
+
+#[test]
+fn status_reports_expiry_without_erroring() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 7);
+    let att =
+        s.h.client
+            .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    s.h.env
+        .ledger()
+        .with_mut(|l| l.sequence_number = att.expires_at + 1);
+
+    let status = s.h.client.attestation_status(&signals.metadata_commitment);
+    assert!(status.exists);
+    assert!(status.expired);
+    assert!(!status.valid);
+}
+
+#[test]
+fn status_of_an_unknown_commitment_is_empty() {
+    let s = scenario();
+    let status =
+        s.h.client
+            .attestation_status(&super::digest32(&s.h.env, 0xF1));
+    assert!(!status.exists);
+    assert!(!status.valid);
+    assert_eq!(status.policy_version, 0);
+}
+
+#[test]
+fn policy_admin_can_revoke() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+
+    let signals = s.signals(&issuer, 8);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    s.h.client
+        .revoke_attestation(&s.h.admin, &signals.metadata_commitment, &7);
+
+    let err =
+        s.h.client
+            .try_consume_attestation(&gateway, &signals.metadata_commitment, &issuer)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::AttestationNotFound);
+}
+
+#[test]
+fn revocation_does_not_free_the_nullifier() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 9);
+    let proof = s.proof(&signals);
+    s.h.client.verify_metadata(&issuer, &proof, &signals);
+
+    s.h.client
+        .revoke_attestation(&s.h.admin, &signals.metadata_commitment, &1);
+
+    // Revoking the receipt must not hand back the right to re-submit the proof;
+    // otherwise revocation would be trivially undoable by the issuer.
+    assert!(s.h.client.is_nullifier_spent(&signals.nullifier));
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::NullifierAlreadyUsed);
+}
+
+#[test]
+fn stranger_cannot_revoke() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let stranger = Address::generate(&s.h.env);
+    let signals = s.signals(&issuer, 10);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    let err =
+        s.h.client
+            .try_revoke_attestation(&stranger, &signals.metadata_commitment, &0)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn registering_the_same_consumer_twice_is_rejected() {
+    let s = scenario();
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+    let err =
+        s.h.client
+            .try_register_consumer(&s.h.admin, &gateway)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::ConsumerAlreadyRegistered);
+}
+
+#[test]
+fn consumption_is_counted() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+
+    for n in 11..14u8 {
+        let sig = s.signals(&issuer, n);
+        s.h.client.verify_metadata(&issuer, &s.proof(&sig), &sig);
+        s.h.client
+            .consume_attestation(&gateway, &sig.metadata_commitment, &issuer);
+    }
+
+    let stats = s.h.client.get_stats();
+    assert_eq!(stats.attestations_issued, 3);
+    assert_eq!(stats.attestations_consumed, 3);
+}
+
+#[test]
+fn consuming_an_unknown_commitment_is_reported() {
+    let s = scenario();
+    let gateway = Address::generate(&s.h.env);
+    s.h.client.register_consumer(&s.h.admin, &gateway);
+
+    let err =
+        s.h.client
+            .try_consume_attestation(&gateway, &super::digest32(&s.h.env, 0xC3), &s.h.issuer)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::AttestationNotFound);
+}

--- a/contracts/zk_metadata_verifier/src/test/batch_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/batch_tests.rs
@@ -1,0 +1,167 @@
+//! Batch verification through the contract surface.
+
+use soroban_sdk::{symbol_short, Env, Symbol, Vec};
+
+use super::fixtures::*;
+use super::{register, setup, Harness};
+use crate::errors::Error;
+use crate::types::{Groth16Proof, ScalarBytes};
+
+const ID: Symbol = symbol_short!("batch_v1");
+const ARITY: u32 = 4;
+
+fn batch_harness() -> (Harness<'static>, Trapdoor) {
+    let h = setup();
+    let (vk, td) = synth_vk(&h.env, ARITY, 0);
+    register(&h, &ID, &vk, ARITY);
+    (h, td)
+}
+
+fn make_batch(env: &Env, td: &Trapdoor, n: u32) -> (Vec<Groth16Proof>, Vec<Vec<ScalarBytes>>) {
+    let mut proofs = Vec::new(env);
+    let mut inputs = Vec::new(env);
+    for i in 0..n {
+        let mut xs: Vec<ScalarBytes> = Vec::new(env);
+        for j in 0..ARITY {
+            xs.push_back(crate::field::u32_to_scalar_bytes(env, 7000 + i * 13 + j));
+        }
+        proofs.push_back(synth_proof(env, td, &xs, 1 + i));
+        inputs.push_back(xs);
+    }
+    (proofs, inputs)
+}
+
+#[test]
+fn full_batch_verifies() {
+    let (h, td) = batch_harness();
+    let (proofs, inputs) = make_batch(&h.env, &td, 8);
+    assert!(h.client.verify_batch(&ID, &proofs, &inputs));
+    assert_eq!(h.client.get_stats().batches_verified, 1);
+    assert_eq!(h.client.get_stats().proofs_verified, 8);
+}
+
+#[test]
+fn batch_at_the_configured_cap_verifies() {
+    let (h, td) = batch_harness();
+    let cap = h.client.get_config().max_batch_size;
+    let (proofs, inputs) = make_batch(&h.env, &td, cap);
+    assert!(h.client.verify_batch(&ID, &proofs, &inputs));
+}
+
+#[test]
+fn batch_above_the_cap_is_rejected() {
+    let (h, td) = batch_harness();
+    let mut config = h.client.get_config();
+    config.max_batch_size = 4;
+    h.client.set_config(&h.admin, &config);
+
+    let (proofs, inputs) = make_batch(&h.env, &td, 5);
+    let err = h
+        .client
+        .try_verify_batch(&ID, &proofs, &inputs)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::BatchTooLarge);
+}
+
+#[test]
+fn one_forged_member_sinks_the_batch() {
+    let (h, td) = batch_harness();
+    let (mut proofs, inputs) = make_batch(&h.env, &td, 6);
+    let mut forged = proofs.get_unchecked(4);
+    forged.c = other_g1(&h.env, 5);
+    proofs.set(4, forged);
+
+    let err = h
+        .client
+        .try_verify_batch(&ID, &proofs, &inputs)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::BatchVerificationFailed);
+}
+
+#[test]
+fn diagnose_pinpoints_the_bad_member() {
+    let (h, td) = batch_harness();
+    let (mut proofs, inputs) = make_batch(&h.env, &td, 6);
+    let mut forged = proofs.get_unchecked(1);
+    forged.c = other_g1(&h.env, 9);
+    proofs.set(1, forged);
+
+    let outcome = h.client.diagnose_batch(&ID, &proofs, &inputs);
+    assert!(!outcome.aggregate_ok);
+    assert_eq!(outcome.size, 6);
+    assert_eq!(outcome.failed.len(), 1);
+    assert_eq!(outcome.failed.get_unchecked(0), 1);
+}
+
+#[test]
+fn diagnose_on_a_clean_batch_reports_no_failures() {
+    let (h, td) = batch_harness();
+    let (proofs, inputs) = make_batch(&h.env, &td, 4);
+    let outcome = h.client.diagnose_batch(&ID, &proofs, &inputs);
+    assert!(outcome.aggregate_ok);
+    assert_eq!(outcome.failed.len(), 0);
+}
+
+#[test]
+fn diagnose_finds_multiple_failures() {
+    let (h, td) = batch_harness();
+    let (mut proofs, inputs) = make_batch(&h.env, &td, 5);
+    for i in [0u32, 3u32] {
+        let mut forged = proofs.get_unchecked(i);
+        forged.a = other_g1(&h.env, 100 + i);
+        proofs.set(i, forged);
+    }
+
+    let outcome = h.client.diagnose_batch(&ID, &proofs, &inputs);
+    assert_eq!(outcome.failed.len(), 2);
+    assert_eq!(outcome.failed.get_unchecked(0), 0);
+    assert_eq!(outcome.failed.get_unchecked(1), 3);
+}
+
+#[test]
+fn batch_is_paused_with_the_contract() {
+    let (h, td) = batch_harness();
+    let (proofs, inputs) = make_batch(&h.env, &td, 3);
+    h.client.pause(&h.admin);
+    let err = h
+        .client
+        .try_verify_batch(&ID, &proofs, &inputs)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Paused);
+}
+
+#[test]
+fn batch_against_an_unknown_circuit_is_rejected() {
+    let (h, td) = batch_harness();
+    let (proofs, inputs) = make_batch(&h.env, &td, 2);
+    let err = h
+        .client
+        .try_verify_batch(&symbol_short!("nope"), &proofs, &inputs)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitNotFound);
+}
+
+#[test]
+fn batch_with_wrong_arity_is_rejected() {
+    let (h, td) = batch_harness();
+    let (proofs, _) = make_batch(&h.env, &td, 2);
+    let mut inputs: Vec<Vec<ScalarBytes>> = Vec::new(&h.env);
+    for _ in 0..2 {
+        inputs.push_back(small_inputs(&h.env, ARITY - 1));
+    }
+    let err = h
+        .client
+        .try_verify_batch(&ID, &proofs, &inputs)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PublicInputCountMismatch);
+}

--- a/contracts/zk_metadata_verifier/src/test/fixtures.rs
+++ b/contracts/zk_metadata_verifier/src/test/fixtures.rs
@@ -1,0 +1,247 @@
+//! Test fixtures that build *genuine* Groth16 instances.
+//!
+//! Running a real prover inside a unit test is not practical, but mocking the
+//! pairing check would leave the most important code in the crate untested. The
+//! way out is to construct a verifying key and proof whose discrete logarithms
+//! we know, chosen so that the verification equation holds exactly.
+//!
+//! Write every group element as a multiple of a generator — `A = a·g₁`,
+//! `B = b·g₂`, `α = x·g₁`, `β = y·g₂`, `L = l·g₁`, `γ = c·g₂`, `C = z·g₁`,
+//! `δ = d·g₂`. Bilinearity collapses the whole check into one exponent:
+//!
+//! ```text
+//! e(−A,B)·e(α,β)·e(L,γ)·e(C,δ) = e(g₁,g₂)^(−ab + xy + lc + zd)
+//! ```
+//!
+//! which is the identity iff `−ab + xy + lc + zd ≡ 0 (mod r)`. So we pick
+//! `x, y, c, d, z` and the `IC` logarithms freely, fix `a = 1`, and *solve* for
+//! `b = xy + lc + zd`. The resulting `(A, B, C)` is indistinguishable from a
+//! real proof as far as the verifier is concerned: it goes through the same
+//! decoding, the same subgroup checks, and the same host `pairing_check`.
+//!
+//! `l` depends on the public inputs (`l = ic₀ + Σ xⱼ·icⱼ`), so a proof built
+//! for one input vector genuinely fails against another — which is exactly the
+//! property the negative tests need.
+
+use soroban_sdk::{
+    crypto::bls12_381::{Fr, G1Affine, G2Affine},
+    BytesN, Env, Vec,
+};
+
+use crate::field::checked_scalar;
+use crate::types::{G1Bytes, G2Bytes, Groth16Proof, ScalarBytes, VerifyingKey};
+
+/// Uncompressed BLS12-381 G1 generator: `be(X) || be(Y)`.
+pub const G1_GENERATOR: [u8; 96] = [
+    0x17, 0xf1, 0xd3, 0xa7, 0x31, 0x97, 0xd7, 0x94, 0x26, 0x95, 0x63, 0x8c, 0x4f, 0xa9, 0xac, 0x0f,
+    0xc3, 0x68, 0x8c, 0x4f, 0x97, 0x74, 0xb9, 0x05, 0xa1, 0x4e, 0x3a, 0x3f, 0x17, 0x1b, 0xac, 0x58,
+    0x6c, 0x55, 0xe8, 0x3f, 0xf9, 0x7a, 0x1a, 0xef, 0xfb, 0x3a, 0xf0, 0x0a, 0xdb, 0x22, 0xc6, 0xbb,
+    0x08, 0xb3, 0xf4, 0x81, 0xe3, 0xaa, 0xa0, 0xf1, 0xa0, 0x9e, 0x30, 0xed, 0x74, 0x1d, 0x8a, 0xe4,
+    0xfc, 0xf5, 0xe0, 0x95, 0xd5, 0xd0, 0x0a, 0xf6, 0x00, 0xdb, 0x18, 0xcb, 0x2c, 0x04, 0xb3, 0xed,
+    0xd0, 0x3c, 0xc7, 0x44, 0xa2, 0x88, 0x8a, 0xe4, 0x0c, 0xaa, 0x23, 0x29, 0x46, 0xc5, 0xe7, 0xe1,
+];
+
+/// Uncompressed BLS12-381 G2 generator.
+///
+/// Soroban's G2 layout is `be(X_c1) || be(X_c0) || be(Y_c1) || be(Y_c0)` — the
+/// `c1` component leads. Getting this backwards is the single most common
+/// integration bug when porting a snarkjs verifying key, because the resulting
+/// point is still on the curve and still in the subgroup; only the pairing
+/// disagrees.
+pub const G2_GENERATOR: [u8; 192] = [
+    // X_c1
+    0x13, 0xe0, 0x2b, 0x60, 0x52, 0x71, 0x9f, 0x60, 0x7d, 0xac, 0xd3, 0xa0, 0x88, 0x27, 0x4f, 0x65,
+    0x59, 0x6b, 0xd0, 0xd0, 0x99, 0x20, 0xb6, 0x1a, 0xb5, 0xda, 0x61, 0xbb, 0xdc, 0x7f, 0x50, 0x49,
+    0x33, 0x4c, 0xf1, 0x12, 0x13, 0x94, 0x5d, 0x57, 0xe5, 0xac, 0x7d, 0x05, 0x5d, 0x04, 0x2b, 0x7e,
+    // X_c0
+    0x02, 0x4a, 0xa2, 0xb2, 0xf0, 0x8f, 0x0a, 0x91, 0x26, 0x08, 0x05, 0x27, 0x2d, 0xc5, 0x10, 0x51,
+    0xc6, 0xe4, 0x7a, 0xd4, 0xfa, 0x40, 0x3b, 0x02, 0xb4, 0x51, 0x0b, 0x64, 0x7a, 0xe3, 0xd1, 0x77,
+    0x0b, 0xac, 0x03, 0x26, 0xa8, 0x05, 0xbb, 0xef, 0xd4, 0x80, 0x56, 0xc8, 0xc1, 0x21, 0xbd, 0xb8,
+    // Y_c1
+    0x06, 0x06, 0xc4, 0xa0, 0x2e, 0xa7, 0x34, 0xcc, 0x32, 0xac, 0xd2, 0xb0, 0x2b, 0xc2, 0x8b, 0x99,
+    0xcb, 0x3e, 0x28, 0x7e, 0x85, 0xa7, 0x63, 0xaf, 0x26, 0x74, 0x92, 0xab, 0x57, 0x2e, 0x99, 0xab,
+    0x3f, 0x37, 0x0d, 0x27, 0x5c, 0xec, 0x1d, 0xa1, 0xaa, 0xa9, 0x07, 0x5f, 0xf0, 0x5f, 0x79, 0xbe,
+    // Y_c0
+    0x0c, 0xe5, 0xd5, 0x27, 0x72, 0x7d, 0x6e, 0x11, 0x8c, 0xc9, 0xcd, 0xc6, 0xda, 0x2e, 0x35, 0x1a,
+    0xad, 0xfd, 0x9b, 0xaa, 0x8c, 0xbd, 0xd3, 0xa7, 0x6d, 0x42, 0x9a, 0x69, 0x51, 0x60, 0xd1, 0x2c,
+    0x92, 0x3a, 0xc9, 0xcc, 0x3b, 0xac, 0xa2, 0x89, 0xe1, 0x93, 0x54, 0x86, 0x08, 0xb8, 0x28, 0x01,
+];
+
+/// An `Env` with the metering budget lifted.
+///
+/// A single Groth16 verification costs several hundred million CPU units —
+/// comfortably inside a real Soroban transaction budget once the contract is
+/// compiled with `opt-level = "z"` and LTO, but well past the default test
+/// harness limit when running an unoptimized debug build through the
+/// interpreter. Tests that call the pairing therefore lift the cap; the
+/// `cost_report` test measures the real figure separately.
+pub fn test_env() -> Env {
+    let env = Env::default();
+    env.cost_estimate().budget().reset_unlimited();
+    env
+}
+
+pub fn g1_generator(env: &Env) -> G1Affine {
+    G1Affine::from_array(env, &G1_GENERATOR)
+}
+
+pub fn g2_generator(env: &Env) -> G2Affine {
+    G2Affine::from_array(env, &G2_GENERATOR)
+}
+
+/// `scalar · g₁`, serialized.
+pub fn g1_mul_gen(env: &Env, scalar: &Fr) -> G1Bytes {
+    env.crypto()
+        .bls12_381()
+        .g1_mul(&g1_generator(env), scalar)
+        .to_bytes()
+}
+
+/// `scalar · g₂`, serialized.
+pub fn g2_mul_gen(env: &Env, scalar: &Fr) -> G2Bytes {
+    env.crypto()
+        .bls12_381()
+        .g2_mul(&g2_generator(env), scalar)
+        .to_bytes()
+}
+
+pub fn fr(env: &Env, v: u32) -> Fr {
+    crate::field::scalar_from_u32(env, v)
+}
+
+/// The discrete logarithms behind a synthetic verifying key.
+///
+/// In a real deployment these are the toxic waste of the trusted setup and are
+/// destroyed. Here they are exactly what lets us mint satisfying proofs.
+pub struct Trapdoor {
+    pub alpha: Fr,
+    pub beta: Fr,
+    pub gamma: Fr,
+    pub delta: Fr,
+    /// `ic[j]`'s discrete log; `ic[0]` is the constant term.
+    pub ic: std::vec::Vec<Fr>,
+}
+
+/// Build a synthetic verifying key for a circuit with `num_inputs` public
+/// signals, plus the trapdoor needed to forge satisfying proofs for it.
+///
+/// `seed` varies the key so tests can prove that a proof for one key fails
+/// against another.
+pub fn synth_vk(env: &Env, num_inputs: u32, seed: u32) -> (VerifyingKey, Trapdoor) {
+    let alpha = fr(env, 7 + seed);
+    let beta = fr(env, 11 + seed);
+    let gamma = fr(env, 13 + seed);
+    let delta = fr(env, 17 + seed);
+
+    let mut ic_logs: std::vec::Vec<Fr> = std::vec::Vec::new();
+    let mut ic: Vec<G1Bytes> = Vec::new(env);
+    for j in 0..=num_inputs {
+        // Any nonzero logs work; these are just distinct and small.
+        let log = fr(env, 101 + seed * 31 + j * 3);
+        ic.push_back(g1_mul_gen(env, &log));
+        ic_logs.push(log);
+    }
+
+    let vk = VerifyingKey {
+        alpha_g1: g1_mul_gen(env, &alpha),
+        beta_g2: g2_mul_gen(env, &beta),
+        gamma_g2: g2_mul_gen(env, &gamma),
+        delta_g2: g2_mul_gen(env, &delta),
+        ic,
+    };
+
+    (
+        vk,
+        Trapdoor {
+            alpha,
+            beta,
+            gamma,
+            delta,
+            ic: ic_logs,
+        },
+    )
+}
+
+/// Forge a proof that satisfies the verification equation for `public_inputs`.
+///
+/// `c_log` seeds the `C` component; varying it produces distinct proofs of the
+/// same statement, which mirrors how a real prover's randomness works and lets
+/// batch tests use non-identical members.
+pub fn synth_proof(
+    env: &Env,
+    trapdoor: &Trapdoor,
+    public_inputs: &Vec<ScalarBytes>,
+    c_log: u32,
+) -> Groth16Proof {
+    let bls = env.crypto().bls12_381();
+
+    // l = ic₀ + Σ xⱼ·icⱼ
+    let mut l = trapdoor.ic[0].clone();
+    for j in 0..public_inputs.len() {
+        let x = checked_scalar(&public_inputs.get_unchecked(j)).expect("canonical input");
+        let term = bls.fr_mul(&trapdoor.ic[(j + 1) as usize], &x);
+        l = bls.fr_add(&l, &term);
+    }
+
+    let z = fr(env, c_log);
+
+    // b = xy + lc + zd, with a = 1.
+    let xy = bls.fr_mul(&trapdoor.alpha, &trapdoor.beta);
+    let lc = bls.fr_mul(&l, &trapdoor.gamma);
+    let zd = bls.fr_mul(&z, &trapdoor.delta);
+    let b = bls.fr_add(&bls.fr_add(&xy, &lc), &zd);
+
+    Groth16Proof {
+        a: g1_mul_gen(env, &crate::field::scalar_one(env)),
+        b: g2_mul_gen(env, &b),
+        c: g1_mul_gen(env, &z),
+    }
+}
+
+/// A vector of `n` distinct small public inputs.
+pub fn small_inputs(env: &Env, n: u32) -> Vec<ScalarBytes> {
+    let mut v: Vec<ScalarBytes> = Vec::new(env);
+    for j in 0..n {
+        v.push_back(crate::field::u32_to_scalar_bytes(env, 1000 + j));
+    }
+    v
+}
+
+/// Flip one bit of a G1 encoding's `Y` coordinate.
+///
+/// The result is in range and correctly flagged but no longer satisfies
+/// `y² = x³ + 4`, so the host rejects it during deserialization. The host
+/// signals that by trapping, not by returning — see the note on host traps in
+/// [`crate::groth16`] — so callers must expect a panic, not an `Err`.
+pub fn corrupt_g1(env: &Env, point: &G1Bytes) -> G1Bytes {
+    let mut arr = point.to_array();
+    arr[95] ^= 0x01;
+    BytesN::from_array(env, &arr)
+}
+
+/// Same, for G2.
+pub fn corrupt_g2(env: &Env, point: &G2Bytes) -> G2Bytes {
+    let mut arr = point.to_array();
+    arr[191] ^= 0x01;
+    BytesN::from_array(env, &arr)
+}
+
+/// A different, perfectly valid G1 point.
+///
+/// Substituting this into a proof exercises the pairing check itself rather
+/// than the encoding guards: everything decodes, every subgroup check passes,
+/// and the equation simply does not hold.
+pub fn other_g1(env: &Env, seed: u32) -> G1Bytes {
+    g1_mul_gen(env, &fr(env, 900_001 + seed))
+}
+
+/// A different, perfectly valid G2 point.
+pub fn other_g2(env: &Env, seed: u32) -> G2Bytes {
+    g2_mul_gen(env, &fr(env, 800_001 + seed))
+}
+
+/// A 32-byte value equal to the field modulus `r` — the canonical
+/// non-canonical scalar.
+pub fn modulus_scalar(env: &Env) -> ScalarBytes {
+    BytesN::from_array(env, &crate::field::FR_MODULUS_BE)
+}

--- a/contracts/zk_metadata_verifier/src/test/groth16_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/groth16_tests.rs
@@ -1,0 +1,438 @@
+//! Direct tests of the pairing verifier, bypassing the contract surface.
+
+use soroban_sdk::{Env, Vec};
+
+use super::fixtures::*;
+use crate::errors::Error;
+use crate::groth16::{
+    locate_batch_failures, public_input_commitment, validate_verifying_key, verify_batch,
+    verify_proof, verifying_key_digest, MAX_PUBLIC_INPUTS,
+};
+use crate::types::ScalarBytes;
+
+#[test]
+fn synthetic_proof_verifies() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 4, 0);
+    let inputs = small_inputs(&env, 4);
+    let proof = synth_proof(&env, &td, &inputs, 42);
+
+    assert_eq!(verify_proof(&env, &vk, &proof, &inputs), Ok(()));
+}
+
+#[test]
+fn zero_input_circuit_verifies() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 0, 3);
+    let inputs: Vec<ScalarBytes> = Vec::new(&env);
+    let proof = synth_proof(&env, &td, &inputs, 9);
+
+    assert_eq!(verify_proof(&env, &vk, &proof, &inputs), Ok(()));
+}
+
+#[test]
+fn wide_circuit_verifies() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, MAX_PUBLIC_INPUTS, 5);
+    let inputs = small_inputs(&env, MAX_PUBLIC_INPUTS);
+    let proof = synth_proof(&env, &td, &inputs, 77);
+
+    assert_eq!(verify_proof(&env, &vk, &proof, &inputs), Ok(()));
+}
+
+#[test]
+fn proof_for_other_inputs_fails() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 4, 0);
+    let inputs = small_inputs(&env, 4);
+    let proof = synth_proof(&env, &td, &inputs, 42);
+
+    // Same arity, different values: `l` changes, so the exponent no longer
+    // cancels. This is the property that makes the fixtures meaningful.
+    let mut other: Vec<ScalarBytes> = Vec::new(&env);
+    for j in 0..4u32 {
+        other.push_back(crate::field::u32_to_scalar_bytes(&env, 2000 + j));
+    }
+
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &other),
+        Err(Error::ProofVerificationFailed)
+    );
+}
+
+#[test]
+fn proof_against_other_verifying_key_fails() {
+    let env = test_env();
+    let (_vk_a, td_a) = synth_vk(&env, 3, 0);
+    let (vk_b, _td_b) = synth_vk(&env, 3, 1);
+    let inputs = small_inputs(&env, 3);
+    let proof = synth_proof(&env, &td_a, &inputs, 11);
+
+    assert_eq!(
+        verify_proof(&env, &vk_b, &proof, &inputs),
+        Err(Error::ProofVerificationFailed)
+    );
+}
+
+#[test]
+fn substituted_a_fails() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let inputs = small_inputs(&env, 2);
+    let mut proof = synth_proof(&env, &td, &inputs, 5);
+    proof.a = other_g1(&env, 1);
+
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &inputs),
+        Err(Error::ProofVerificationFailed)
+    );
+}
+
+#[test]
+fn substituted_b_fails() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let inputs = small_inputs(&env, 2);
+    let mut proof = synth_proof(&env, &td, &inputs, 5);
+    proof.b = other_g2(&env, 2);
+
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &inputs),
+        Err(Error::ProofVerificationFailed)
+    );
+}
+
+#[test]
+fn substituted_c_fails() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let inputs = small_inputs(&env, 2);
+    let mut proof = synth_proof(&env, &td, &inputs, 5);
+    proof.c = other_g1(&env, 3);
+
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &inputs),
+        Err(Error::ProofVerificationFailed)
+    );
+}
+
+/// An off-curve `A` is refused by the host during deserialization, which it
+/// reports by trapping rather than returning. Pinning that as a test documents
+/// the boundary: the contract's own guards cover flags, ranges and subgroup
+/// membership, and curve membership is the host's job.
+#[test]
+#[should_panic]
+fn off_curve_a_traps_in_host() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let inputs = small_inputs(&env, 2);
+    let mut proof = synth_proof(&env, &td, &inputs, 5);
+    proof.a = corrupt_g1(&env, &proof.a);
+    let _ = verify_proof(&env, &vk, &proof, &inputs);
+}
+
+#[test]
+#[should_panic]
+fn off_curve_b_traps_in_host() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let inputs = small_inputs(&env, 2);
+    let mut proof = synth_proof(&env, &td, &inputs, 5);
+    proof.b = corrupt_g2(&env, &proof.b);
+    let _ = verify_proof(&env, &vk, &proof, &inputs);
+}
+
+#[test]
+fn swapping_a_and_c_fails() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let inputs = small_inputs(&env, 2);
+    let mut proof = synth_proof(&env, &td, &inputs, 5);
+    core::mem::swap(&mut proof.a, &mut proof.c);
+
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &inputs),
+        Err(Error::ProofVerificationFailed)
+    );
+}
+
+#[test]
+fn wrong_input_count_is_caught_before_pairing() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 4, 0);
+    let inputs = small_inputs(&env, 4);
+    let proof = synth_proof(&env, &td, &inputs, 1);
+
+    let short = small_inputs(&env, 3);
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &short),
+        Err(Error::PublicInputCountMismatch)
+    );
+}
+
+#[test]
+fn non_canonical_scalar_is_rejected() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 1, 0);
+    let inputs = small_inputs(&env, 1);
+    let proof = synth_proof(&env, &td, &inputs, 1);
+
+    let mut bad: Vec<ScalarBytes> = Vec::new(&env);
+    bad.push_back(modulus_scalar(&env));
+
+    assert_eq!(
+        verify_proof(&env, &vk, &proof, &bad),
+        Err(Error::NonCanonicalScalar)
+    );
+}
+
+#[test]
+fn validate_vk_rejects_arity_mismatch() {
+    let env = test_env();
+    let (vk, _) = synth_vk(&env, 4, 0);
+    assert_eq!(
+        validate_verifying_key(&env, &vk, 3),
+        Err(Error::MalformedVerifyingKey)
+    );
+    assert_eq!(validate_verifying_key(&env, &vk, 4), Ok(()));
+}
+
+#[test]
+fn validate_vk_rejects_oversized_arity() {
+    let env = test_env();
+    let (vk, _) = synth_vk(&env, 2, 0);
+    assert_eq!(
+        validate_verifying_key(&env, &vk, MAX_PUBLIC_INPUTS + 1),
+        Err(Error::UnsupportedArity)
+    );
+}
+
+#[test]
+#[should_panic]
+fn validate_vk_rejects_off_curve_point() {
+    let env = test_env();
+    let (mut vk, _) = synth_vk(&env, 2, 0);
+    vk.alpha_g1 = corrupt_g1(&env, &vk.alpha_g1);
+    let _ = validate_verifying_key(&env, &vk, 2);
+}
+
+#[test]
+fn validate_vk_rejects_out_of_range_point() {
+    let env = test_env();
+    let (mut vk, _) = synth_vk(&env, 2, 0);
+    vk.alpha_g1 = soroban_sdk::BytesN::from_array(&env, &[0xffu8; 96]);
+    assert_eq!(
+        validate_verifying_key(&env, &vk, 2),
+        Err(Error::InvalidG1Point)
+    );
+}
+
+#[test]
+fn validate_vk_rejects_infinite_delta() {
+    let env = test_env();
+    let (mut vk, _) = synth_vk(&env, 2, 0);
+    let mut inf = [0u8; 192];
+    inf[0] = 0x40;
+    vk.delta_g2 = soroban_sdk::BytesN::from_array(&env, &inf);
+    assert_eq!(
+        validate_verifying_key(&env, &vk, 2),
+        Err(Error::PointAtInfinity)
+    );
+}
+
+#[test]
+fn vk_digest_is_stable_and_distinguishing() {
+    let env = test_env();
+    let (vk_a, _) = synth_vk(&env, 3, 0);
+    let (vk_b, _) = synth_vk(&env, 3, 1);
+
+    assert_eq!(
+        verifying_key_digest(&env, &vk_a, 3),
+        verifying_key_digest(&env, &vk_a, 3)
+    );
+    assert_ne!(
+        verifying_key_digest(&env, &vk_a, 3),
+        verifying_key_digest(&env, &vk_b, 3)
+    );
+    // Arity participates in the digest, so a key cannot be silently reused at a
+    // different arity.
+    assert_ne!(
+        verifying_key_digest(&env, &vk_a, 3),
+        verifying_key_digest(&env, &vk_a, 2)
+    );
+}
+
+#[test]
+fn public_input_commitment_matches_manual_msm() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 3, 0);
+    let inputs = small_inputs(&env, 3);
+
+    let l = public_input_commitment(&env, &vk, &inputs).unwrap();
+
+    // Recompute from the trapdoor: l = ic₀ + Σ xⱼ·icⱼ, then l·g₁.
+    let bls = env.crypto().bls12_381();
+    let mut log = td.ic[0].clone();
+    for j in 0..3usize {
+        let x = crate::field::checked_scalar(&inputs.get_unchecked(j as u32)).unwrap();
+        log = bls.fr_add(&log, &bls.fr_mul(&td.ic[j + 1], &x));
+    }
+    assert_eq!(l.to_bytes(), g1_mul_gen(&env, &log));
+}
+
+// ---------------------------------------------------------------------------
+// Batch verification
+// ---------------------------------------------------------------------------
+
+fn batch_of(
+    env: &Env,
+    td: &Trapdoor,
+    n: u32,
+    arity: u32,
+) -> (Vec<crate::types::Groth16Proof>, Vec<Vec<ScalarBytes>>) {
+    let mut proofs = Vec::new(env);
+    let mut inputs = Vec::new(env);
+    for i in 0..n {
+        let mut xs: Vec<ScalarBytes> = Vec::new(env);
+        for j in 0..arity {
+            xs.push_back(crate::field::u32_to_scalar_bytes(env, 500 + i * 17 + j));
+        }
+        proofs.push_back(synth_proof(env, td, &xs, 3 + i));
+        inputs.push_back(xs);
+    }
+    (proofs, inputs)
+}
+
+#[test]
+fn batch_of_valid_proofs_verifies() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 4, 0);
+    let digest = verifying_key_digest(&env, &vk, 4);
+    let (proofs, inputs) = batch_of(&env, &td, 8, 4);
+
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &proofs, &inputs, 16),
+        Ok(())
+    );
+}
+
+#[test]
+fn single_element_batch_verifies() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let digest = verifying_key_digest(&env, &vk, 2);
+    let (proofs, inputs) = batch_of(&env, &td, 1, 2);
+
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &proofs, &inputs, 16),
+        Ok(())
+    );
+}
+
+#[test]
+fn batch_with_one_bad_proof_fails() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 3, 0);
+    let digest = verifying_key_digest(&env, &vk, 3);
+    let (mut proofs, inputs) = batch_of(&env, &td, 5, 3);
+
+    // Replace member 2 with a proof for a different statement. It is a
+    // perfectly valid proof — just not of the claim its slot advertises.
+    let decoy = small_inputs(&env, 3);
+    proofs.set(2, synth_proof(&env, &td, &decoy, 99));
+
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &proofs, &inputs, 16),
+        Err(Error::BatchVerificationFailed)
+    );
+}
+
+#[test]
+fn batch_failure_is_attributable() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 3, 0);
+    let (mut proofs, inputs) = batch_of(&env, &td, 5, 3);
+    let decoy = small_inputs(&env, 3);
+    proofs.set(3, synth_proof(&env, &td, &decoy, 99));
+
+    let failed = locate_batch_failures(&env, &vk, &proofs, &inputs);
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed.get_unchecked(0), 3);
+}
+
+#[test]
+fn reordering_a_batch_still_verifies() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let digest = verifying_key_digest(&env, &vk, 2);
+    let (proofs, inputs) = batch_of(&env, &td, 4, 2);
+
+    let mut rp = Vec::new(&env);
+    let mut ri = Vec::new(&env);
+    for i in (0..4u32).rev() {
+        rp.push_back(proofs.get_unchecked(i));
+        ri.push_back(inputs.get_unchecked(i));
+    }
+
+    // The transcript changes, so every coefficient changes — but each member is
+    // still individually valid, so the aggregate holds.
+    assert_eq!(verify_batch(&env, &vk, &digest, &rp, &ri, 16), Ok(()));
+}
+
+#[test]
+fn mismatched_batch_pairing_is_detected() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 2, 0);
+    let digest = verifying_key_digest(&env, &vk, 2);
+    let (proofs, mut inputs) = batch_of(&env, &td, 3, 2);
+
+    // Pair proof 0 with proof 1's inputs and vice versa. Each proof is valid
+    // and each input vector is legitimate; only the pairing is wrong. A naive
+    // "sum of proofs, sum of inputs" batcher would accept this.
+    let a = inputs.get_unchecked(0);
+    let b = inputs.get_unchecked(1);
+    inputs.set(0, b);
+    inputs.set(1, a);
+
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &proofs, &inputs, 16),
+        Err(Error::BatchVerificationFailed)
+    );
+}
+
+#[test]
+fn empty_batch_is_rejected() {
+    let env = test_env();
+    let (vk, _) = synth_vk(&env, 2, 0);
+    let digest = verifying_key_digest(&env, &vk, 2);
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &Vec::new(&env), &Vec::new(&env), 16),
+        Err(Error::EmptyBatch)
+    );
+}
+
+#[test]
+fn oversized_batch_is_rejected() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 1, 0);
+    let digest = verifying_key_digest(&env, &vk, 1);
+    let (proofs, inputs) = batch_of(&env, &td, 5, 1);
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &proofs, &inputs, 4),
+        Err(Error::BatchTooLarge)
+    );
+}
+
+#[test]
+fn batch_length_mismatch_is_rejected() {
+    let env = test_env();
+    let (vk, td) = synth_vk(&env, 1, 0);
+    let digest = verifying_key_digest(&env, &vk, 1);
+    let (proofs, inputs) = batch_of(&env, &td, 3, 1);
+    let mut short = Vec::new(&env);
+    short.push_back(inputs.get_unchecked(0));
+    assert_eq!(
+        verify_batch(&env, &vk, &digest, &proofs, &short, 16),
+        Err(Error::BatchLengthMismatch)
+    );
+}

--- a/contracts/zk_metadata_verifier/src/test/mod.rs
+++ b/contracts/zk_metadata_verifier/src/test/mod.rs
@@ -1,0 +1,153 @@
+//! Test suite.
+//!
+//! `fixtures` builds real, satisfying Groth16 instances (see its module docs),
+//! so every test below exercises the actual host pairing path.
+
+mod fixtures;
+
+mod access_tests;
+mod attestation_tests;
+mod batch_tests;
+mod groth16_tests;
+mod policy_tests;
+mod registry_tests;
+mod verification_tests;
+
+use soroban_sdk::{
+    symbol_short, testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String,
+    Symbol,
+};
+
+use crate::contract::{ZkMetadataVerifier, ZkMetadataVerifierClient};
+use crate::types::{Digest, Groth16Proof, MetadataSignals, PolicyParams, VerifyingKey};
+
+pub const METADATA_ARITY: u32 = crate::policy::METADATA_ARITY;
+
+/// Ledger the harness starts at.
+pub const START_LEDGER: u32 = 100_000;
+/// Circuit id used by the metadata scenario.
+pub const METADATA_CIRCUIT: Symbol = symbol_short!("meta_v1");
+/// Proof validity window used by the metadata scenario (~1 day).
+pub const VALIDITY_WINDOW: u32 = 17_280;
+
+/// A deployed verifier plus the addresses used to drive it.
+pub struct Harness<'a> {
+    pub env: Env,
+    pub client: ZkMetadataVerifierClient<'a>,
+    /// Kept so tests can register the verifier as another contract's
+    /// dependency; read by the gateway crate's integration tests.
+    #[allow(dead_code)]
+    pub contract_id: Address,
+    pub admin: Address,
+    pub issuer: Address,
+}
+
+pub fn setup() -> Harness<'static> {
+    let env = Env::default();
+    env.cost_estimate().budget().reset_unlimited();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    // A non-zero starting ledger keeps expiry arithmetic realistic; at
+    // sequence 0 every "expires_at" comparison is trivially satisfied and the
+    // freshness tests would prove nothing.
+    env.ledger().with_mut(|l| l.sequence_number = START_LEDGER);
+    let contract_id = env.register(ZkMetadataVerifier, ());
+    let client = ZkMetadataVerifierClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    Harness {
+        env,
+        client,
+        contract_id,
+        admin,
+        issuer,
+    }
+}
+
+/// Register `circuit_id` with a synthetic key of the given arity.
+pub fn register(h: &Harness, circuit_id: &Symbol, vk: &VerifyingKey, arity: u32) {
+    h.client.register_circuit(
+        &h.admin,
+        circuit_id,
+        vk,
+        &arity,
+        &String::from_str(&h.env, "test-fixture"),
+    );
+}
+
+/// Publish and activate a policy in one step.
+pub fn activate_policy(h: &Harness, params: &PolicyParams) {
+    h.client.publish_policy(&h.admin, params);
+    h.client.activate_policy(&h.admin, &params.version);
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end metadata scenario
+// ---------------------------------------------------------------------------
+
+/// A 32-byte value that is guaranteed to be a canonical `Fr` element.
+///
+/// Real commitments come out of Poseidon, which already outputs field
+/// elements. Here the top byte is simply zeroed, which is enough for the
+/// scalar to be well under `r`.
+pub fn digest32(env: &Env, seed: u8) -> Digest {
+    let mut arr = [0u8; 32];
+    arr[31] = seed;
+    arr[30] = seed.wrapping_mul(7);
+    arr[17] = seed.wrapping_add(0x5a);
+    BytesN::from_array(env, &arr)
+}
+
+/// A verifier with the metadata circuit registered and a policy in force.
+pub struct Scenario<'a> {
+    pub h: Harness<'a>,
+    pub trapdoor: fixtures::Trapdoor,
+    pub policy: PolicyParams,
+}
+
+pub fn scenario() -> Scenario<'static> {
+    let h = setup();
+    let (vk, trapdoor) = fixtures::synth_vk(&h.env, METADATA_ARITY, 0);
+    register(&h, &METADATA_CIRCUIT, &vk, METADATA_ARITY);
+
+    let policy = PolicyParams {
+        version: 1,
+        policy_root: digest32(&h.env, 0x11),
+        model_commitment: digest32(&h.env, 0x22),
+        max_risk_score: 250,
+        risk_scale: 1000,
+        max_validity_ledgers: VALIDITY_WINDOW,
+        circuit_id: METADATA_CIRCUIT,
+        rulebook_uri: String::from_str(&h.env, "ipfs://policy-v1"),
+    };
+    activate_policy(&h, &policy);
+
+    Scenario {
+        h,
+        trapdoor,
+        policy,
+    }
+}
+
+impl Scenario<'_> {
+    /// Well-formed signals for `issuer`, accepted by the active policy.
+    pub fn signals(&self, issuer: &Address, nonce: u8) -> MetadataSignals {
+        MetadataSignals {
+            verdict: crate::policy::VERDICT_SAFE,
+            risk_score: 42,
+            policy_root: self.policy.policy_root.clone(),
+            model_commitment: self.policy.model_commitment.clone(),
+            metadata_commitment: digest32(&self.h.env, 0x40 | nonce),
+            issuer_hash: self.h.client.compute_issuer_hash(issuer),
+            nullifier: digest32(&self.h.env, 0x80 | nonce),
+            expiry_ledger: START_LEDGER + VALIDITY_WINDOW / 2,
+        }
+    }
+
+    /// A proof that genuinely satisfies the verification equation for
+    /// `signals` under the registered key.
+    pub fn proof(&self, signals: &MetadataSignals) -> Groth16Proof {
+        let inputs = crate::policy::signals_to_public_inputs(&self.h.env, signals);
+        fixtures::synth_proof(&self.h.env, &self.trapdoor, &inputs, 31337)
+    }
+}

--- a/contracts/zk_metadata_verifier/src/test/policy_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/policy_tests.rs
@@ -1,0 +1,319 @@
+//! Policy publication, activation and parameter validation.
+
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, String};
+
+use super::{
+    digest32, register, scenario, setup, METADATA_ARITY, METADATA_CIRCUIT, VALIDITY_WINDOW,
+};
+use crate::errors::Error;
+use crate::types::{PolicyParams, Role};
+
+fn params(env: &soroban_sdk::Env, version: u32) -> PolicyParams {
+    PolicyParams {
+        version,
+        policy_root: digest32(env, 0x11),
+        model_commitment: digest32(env, 0x22),
+        max_risk_score: 250,
+        risk_scale: 1000,
+        max_validity_ledgers: VALIDITY_WINDOW,
+        circuit_id: METADATA_CIRCUIT,
+        rulebook_uri: String::from_str(env, "ipfs://policy"),
+    }
+}
+
+fn with_circuit() -> super::Harness<'static> {
+    let h = setup();
+    let (vk, _) = super::fixtures::synth_vk(&h.env, METADATA_ARITY, 0);
+    register(&h, &METADATA_CIRCUIT, &vk, METADATA_ARITY);
+    h
+}
+
+#[test]
+fn publish_then_activate() {
+    let h = with_circuit();
+    let p = params(&h.env, 1);
+    h.client.publish_policy(&h.admin, &p);
+
+    // Publishing alone must not change what verification enforces; an operator
+    // needs to be able to stage a policy and activate it deliberately.
+    assert!(h.client.try_get_active_policy().is_err());
+
+    h.client.activate_policy(&h.admin, &1);
+    let active = h.client.get_active_policy();
+    assert_eq!(active.version, 1);
+    assert_eq!(active.max_risk_score, 250);
+    assert_eq!(active.activated_at, super::START_LEDGER);
+}
+
+#[test]
+fn versions_must_increase() {
+    let h = with_circuit();
+    h.client.publish_policy(&h.admin, &params(&h.env, 5));
+    h.client.activate_policy(&h.admin, &5);
+
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &params(&h.env, 4))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyVersionRegression);
+}
+
+#[test]
+fn republishing_the_active_version_is_rejected() {
+    let h = with_circuit();
+    h.client.publish_policy(&h.admin, &params(&h.env, 3));
+    h.client.activate_policy(&h.admin, &3);
+
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &params(&h.env, 3))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyVersionRegression);
+}
+
+#[test]
+fn version_zero_is_rejected() {
+    let h = with_circuit();
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &params(&h.env, 0))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidPolicyParameters);
+}
+
+#[test]
+fn threshold_above_the_scale_is_rejected() {
+    let h = with_circuit();
+    let mut p = params(&h.env, 1);
+    p.max_risk_score = 1001;
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &p)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidPolicyParameters);
+}
+
+#[test]
+fn zero_scale_is_rejected() {
+    let h = with_circuit();
+    let mut p = params(&h.env, 1);
+    p.risk_scale = 0;
+    p.max_risk_score = 0;
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &p)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidPolicyParameters);
+}
+
+#[test]
+fn validity_window_longer_than_nullifier_retention_is_rejected() {
+    let h = with_circuit();
+    let mut p = params(&h.env, 1);
+    p.max_validity_ledgers = h.client.get_config().nullifier_ttl;
+
+    // If a proof could stay valid longer than its nullifier is retained, the
+    // nullifier would expire while the proof was still redeemable — reopening
+    // the replay it exists to prevent.
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &p)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidPolicyParameters);
+}
+
+#[test]
+fn zero_validity_window_is_rejected() {
+    let h = with_circuit();
+    let mut p = params(&h.env, 1);
+    p.max_validity_ledgers = 0;
+    let err = h
+        .client
+        .try_publish_policy(&h.admin, &p)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::InvalidPolicyParameters);
+}
+
+#[test]
+fn activating_an_unpublished_version_is_rejected() {
+    let h = with_circuit();
+    let err = h
+        .client
+        .try_activate_policy(&h.admin, &9)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyNotFound);
+}
+
+#[test]
+fn activating_a_policy_that_names_a_missing_circuit_is_rejected() {
+    let h = setup();
+    let mut p = params(&h.env, 1);
+    p.circuit_id = symbol_short!("absent");
+    h.client.publish_policy(&h.admin, &p);
+
+    let err = h
+        .client
+        .try_activate_policy(&h.admin, &1)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitNotFound);
+}
+
+#[test]
+fn activating_a_policy_that_names_a_disabled_circuit_is_rejected() {
+    let h = with_circuit();
+    h.client.publish_policy(&h.admin, &params(&h.env, 1));
+    h.client
+        .set_circuit_enabled(&h.admin, &METADATA_CIRCUIT, &false);
+
+    let err = h
+        .client
+        .try_activate_policy(&h.admin, &1)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitDisabled);
+}
+
+#[test]
+fn non_policy_admin_cannot_publish() {
+    let h = with_circuit();
+    let stranger = Address::generate(&h.env);
+    let err = h
+        .client
+        .try_publish_policy(&stranger, &params(&h.env, 1))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn delegated_policy_admin_can_publish_and_activate() {
+    let h = with_circuit();
+    let delegate = Address::generate(&h.env);
+    h.client.grant_role(&h.admin, &Role::PolicyAdmin, &delegate);
+
+    h.client.publish_policy(&delegate, &params(&h.env, 1));
+    h.client.activate_policy(&delegate, &1);
+    assert_eq!(h.client.get_active_policy().version, 1);
+}
+
+#[test]
+fn policy_admin_cannot_touch_the_circuit_registry() {
+    let h = with_circuit();
+    let delegate = Address::generate(&h.env);
+    h.client.grant_role(&h.admin, &Role::PolicyAdmin, &delegate);
+
+    // Separating these two keys is the point: loosening a threshold is
+    // recoverable, installing a forged verifying key is not.
+    let (vk, _) = super::fixtures::synth_vk(&h.env, 2, 3);
+    let err = h
+        .client
+        .try_register_circuit(
+            &delegate,
+            &symbol_short!("sneaky"),
+            &vk,
+            &2,
+            &String::from_str(&h.env, "x"),
+        )
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn policies_are_indexed() {
+    let h = with_circuit();
+    h.client.publish_policy(&h.admin, &params(&h.env, 1));
+    h.client.activate_policy(&h.admin, &1);
+    h.client.publish_policy(&h.admin, &params(&h.env, 2));
+
+    let list = h.client.list_policies();
+    assert_eq!(list.len(), 2);
+    assert_eq!(list.get_unchecked(0), 1);
+    assert_eq!(list.get_unchecked(1), 2);
+}
+
+#[test]
+fn superseded_policy_stays_readable() {
+    let h = with_circuit();
+    h.client.publish_policy(&h.admin, &params(&h.env, 1));
+    h.client.activate_policy(&h.admin, &1);
+
+    let mut p2 = params(&h.env, 2);
+    p2.max_risk_score = 100;
+    h.client.publish_policy(&h.admin, &p2);
+    h.client.activate_policy(&h.admin, &2);
+
+    // Attestations record the version they were issued under, so historical
+    // policies must remain queryable to interpret them.
+    assert_eq!(h.client.get_policy(&1).max_risk_score, 250);
+    assert_eq!(h.client.get_active_policy().max_risk_score, 100);
+}
+
+#[test]
+fn a_new_policy_changes_which_proofs_are_accepted() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+
+    let signals = s.signals(&issuer, 1);
+    let proof = s.proof(&signals);
+
+    // Tighten the threshold below the proof's score, keeping everything else.
+    let mut p2 = s.policy.clone();
+    p2.version = 2;
+    p2.max_risk_score = 10;
+    s.h.client.publish_policy(&s.h.admin, &p2);
+    s.h.client.activate_policy(&s.h.admin, &2);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::RiskScoreTooHigh);
+}
+
+#[test]
+fn rotating_the_policy_root_invalidates_old_proofs() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 2);
+    let proof = s.proof(&signals);
+
+    let mut p2 = s.policy.clone();
+    p2.version = 2;
+    p2.policy_root = digest32(&s.h.env, 0x99);
+    s.h.client.publish_policy(&s.h.admin, &p2);
+    s.h.client.activate_policy(&s.h.admin, &2);
+
+    // The rule set moved; a proof that a payload passed the *old* rules is no
+    // longer a statement about anything the platform enforces.
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::PolicyRootMismatch);
+}

--- a/contracts/zk_metadata_verifier/src/test/registry_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/registry_tests.rs
@@ -1,0 +1,336 @@
+//! Circuit registry: registration, timelocked rotation, freezing.
+
+use soroban_sdk::{symbol_short, testutils::Address as _, testutils::Ledger as _, Address, String};
+
+use super::fixtures::*;
+use super::{register, setup};
+use crate::errors::Error;
+use crate::types::Role;
+
+#[test]
+fn register_then_read_back() {
+    let h = setup();
+    let (vk, _) = synth_vk(&h.env, 8, 0);
+    let id = symbol_short!("meta_v1");
+    register(&h, &id, &vk, 8);
+
+    let record = h.client.get_circuit(&id);
+    assert_eq!(record.circuit_id, id);
+    assert_eq!(record.num_public_inputs, 8);
+    assert!(record.enabled);
+    assert!(!record.frozen);
+    assert_eq!(record.revision, 0);
+    assert_eq!(record.verifications, 0);
+    assert_eq!(
+        record.vk_digest,
+        h.client.compute_vk_digest(&vk, &8),
+        "the digest an operator computes off chain must match the stored one"
+    );
+}
+
+#[test]
+fn registering_twice_is_rejected() {
+    let h = setup();
+    let (vk, _) = synth_vk(&h.env, 4, 0);
+    let id = symbol_short!("dup");
+    register(&h, &id, &vk, 4);
+
+    let err = h
+        .client
+        .try_register_circuit(&h.admin, &id, &vk, &4, &String::from_str(&h.env, "x"))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitAlreadyExists);
+}
+
+#[test]
+fn arity_mismatch_is_rejected_at_registration() {
+    let h = setup();
+    let (vk, _) = synth_vk(&h.env, 4, 0);
+    let err = h
+        .client
+        .try_register_circuit(
+            &h.admin,
+            &symbol_short!("bad"),
+            &vk,
+            &5,
+            &String::from_str(&h.env, "x"),
+        )
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::MalformedVerifyingKey);
+}
+
+#[test]
+fn non_circuit_admin_cannot_register() {
+    let h = setup();
+    let stranger = Address::generate(&h.env);
+    let (vk, _) = synth_vk(&h.env, 2, 0);
+
+    let err = h
+        .client
+        .try_register_circuit(
+            &stranger,
+            &symbol_short!("nope"),
+            &vk,
+            &2,
+            &String::from_str(&h.env, "x"),
+        )
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn delegated_circuit_admin_can_register() {
+    let h = setup();
+    let delegate = Address::generate(&h.env);
+    h.client
+        .grant_role(&h.admin, &Role::CircuitAdmin, &delegate);
+
+    let (vk, _) = synth_vk(&h.env, 2, 0);
+    h.client.register_circuit(
+        &delegate,
+        &symbol_short!("deleg"),
+        &vk,
+        &2,
+        &String::from_str(&h.env, "x"),
+    );
+    assert_eq!(h.client.get_circuit(&symbol_short!("deleg")).revision, 0);
+}
+
+#[test]
+fn rotation_requires_the_timelock_to_elapse() {
+    let h = setup();
+    let id = symbol_short!("rot");
+    let (vk0, _) = synth_vk(&h.env, 3, 0);
+    let (vk1, _) = synth_vk(&h.env, 3, 1);
+    register(&h, &id, &vk0, 3);
+
+    let eta = h.client.propose_rotation(&h.admin, &id, &vk1, &3);
+    assert!(eta > h.env.ledger().sequence());
+
+    let err = h
+        .client
+        .try_finalize_rotation(&h.admin, &id)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::RotationTimelockActive);
+
+    h.env.ledger().with_mut(|l| l.sequence_number = eta);
+    let new_digest = h.client.finalize_rotation(&h.admin, &id);
+
+    let record = h.client.get_circuit(&id);
+    assert_eq!(record.revision, 1);
+    assert_eq!(record.vk_digest, new_digest);
+    assert_eq!(new_digest, h.client.compute_vk_digest(&vk1, &3));
+}
+
+#[test]
+fn pending_rotation_publishes_the_incoming_digest() {
+    let h = setup();
+    let id = symbol_short!("rot2");
+    let (vk0, _) = synth_vk(&h.env, 2, 0);
+    let (vk1, _) = synth_vk(&h.env, 2, 7);
+    register(&h, &id, &vk0, 2);
+    h.client.propose_rotation(&h.admin, &id, &vk1, &2);
+
+    // The whole point of the timelock: the incoming key is auditable *before*
+    // it becomes live.
+    let pending = h.client.get_rotation(&id);
+    assert_eq!(pending.vk_digest, h.client.compute_vk_digest(&vk1, &2));
+    assert_eq!(pending.proposer, h.admin);
+}
+
+#[test]
+fn rotation_to_an_identical_key_is_rejected() {
+    let h = setup();
+    let id = symbol_short!("same");
+    let (vk, _) = synth_vk(&h.env, 2, 0);
+    register(&h, &id, &vk, 2);
+
+    let err = h
+        .client
+        .try_propose_rotation(&h.admin, &id, &vk, &2)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::VerifyingKeyUnchanged);
+}
+
+#[test]
+fn cancelled_rotation_cannot_be_finalized() {
+    let h = setup();
+    let id = symbol_short!("cancel");
+    let (vk0, _) = synth_vk(&h.env, 2, 0);
+    let (vk1, _) = synth_vk(&h.env, 2, 4);
+    register(&h, &id, &vk0, 2);
+
+    let eta = h.client.propose_rotation(&h.admin, &id, &vk1, &2);
+    h.client.cancel_rotation(&h.admin, &id);
+    h.env.ledger().with_mut(|l| l.sequence_number = eta);
+
+    let err = h
+        .client
+        .try_finalize_rotation(&h.admin, &id)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::NoPendingRotation);
+}
+
+#[test]
+fn cancelling_nothing_is_an_error() {
+    let h = setup();
+    let id = symbol_short!("nothing");
+    let (vk, _) = synth_vk(&h.env, 1, 0);
+    register(&h, &id, &vk, 1);
+
+    let err = h
+        .client
+        .try_cancel_rotation(&h.admin, &id)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::NoPendingRotation);
+}
+
+#[test]
+fn frozen_circuit_cannot_be_rotated() {
+    let h = setup();
+    let id = symbol_short!("frozen");
+    let (vk0, _) = synth_vk(&h.env, 2, 0);
+    let (vk1, _) = synth_vk(&h.env, 2, 9);
+    register(&h, &id, &vk0, 2);
+    h.client.freeze_circuit(&h.admin, &id);
+
+    assert!(h.client.get_circuit(&id).frozen);
+    let err = h
+        .client
+        .try_propose_rotation(&h.admin, &id, &vk1, &2)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitFrozen);
+}
+
+#[test]
+fn freezing_discards_a_pending_rotation() {
+    let h = setup();
+    let id = symbol_short!("frz2");
+    let (vk0, _) = synth_vk(&h.env, 2, 0);
+    let (vk1, _) = synth_vk(&h.env, 2, 12);
+    register(&h, &id, &vk0, 2);
+    let eta = h.client.propose_rotation(&h.admin, &id, &vk1, &2);
+
+    h.client.freeze_circuit(&h.admin, &id);
+    h.env.ledger().with_mut(|l| l.sequence_number = eta);
+
+    // Leaving the rotation queued would show operators a finalizable proposal
+    // that can never succeed.
+    let err = h
+        .client
+        .try_finalize_rotation(&h.admin, &id)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::NoPendingRotation);
+}
+
+#[test]
+fn only_admin_can_freeze() {
+    let h = setup();
+    let id = symbol_short!("frz3");
+    let (vk, _) = synth_vk(&h.env, 1, 0);
+    register(&h, &id, &vk, 1);
+
+    let delegate = Address::generate(&h.env);
+    h.client
+        .grant_role(&h.admin, &Role::CircuitAdmin, &delegate);
+
+    // Freezing is irreversible, so it stays with the root key even though the
+    // delegate can do everything else to this circuit.
+    let err = h
+        .client
+        .try_freeze_circuit(&delegate, &id)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn disabled_circuit_refuses_verification() {
+    let h = setup();
+    let id = symbol_short!("off");
+    let (vk, td) = synth_vk(&h.env, 2, 0);
+    register(&h, &id, &vk, 2);
+
+    let inputs = small_inputs(&h.env, 2);
+    let proof = synth_proof(&h.env, &td, &inputs, 1);
+    assert!(h.client.verify_proof(&id, &proof, &inputs));
+
+    h.client.set_circuit_enabled(&h.admin, &id, &false);
+    let err = h
+        .client
+        .try_verify_proof(&id, &proof, &inputs)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitDisabled);
+
+    h.client.set_circuit_enabled(&h.admin, &id, &true);
+    assert!(h.client.verify_proof(&id, &proof, &inputs));
+}
+
+#[test]
+fn unknown_circuit_is_reported() {
+    let h = setup();
+    let err = h
+        .client
+        .try_get_circuit(&symbol_short!("ghost"))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CircuitNotFound);
+}
+
+#[test]
+fn circuits_are_listed_in_registration_order() {
+    let h = setup();
+    let (vk, _) = synth_vk(&h.env, 1, 0);
+    for id in [symbol_short!("a"), symbol_short!("b"), symbol_short!("c")] {
+        register(&h, &id, &vk, 1);
+    }
+    let listed = h.client.list_circuits();
+    assert_eq!(listed.len(), 3);
+    assert_eq!(listed.get_unchecked(0), symbol_short!("a"));
+    assert_eq!(listed.get_unchecked(2), symbol_short!("c"));
+}
+
+#[test]
+fn rotation_actually_changes_which_proofs_verify() {
+    let h = setup();
+    let id = symbol_short!("live");
+    let (vk0, td0) = synth_vk(&h.env, 2, 0);
+    let (vk1, td1) = synth_vk(&h.env, 2, 21);
+    register(&h, &id, &vk0, 2);
+
+    let inputs = small_inputs(&h.env, 2);
+    let proof_old = synth_proof(&h.env, &td0, &inputs, 5);
+    let proof_new = synth_proof(&h.env, &td1, &inputs, 5);
+
+    assert!(h.client.check_proof(&id, &proof_old, &inputs));
+    assert!(!h.client.check_proof(&id, &proof_new, &inputs));
+
+    let eta = h.client.propose_rotation(&h.admin, &id, &vk1, &2);
+    h.env.ledger().with_mut(|l| l.sequence_number = eta);
+    h.client.finalize_rotation(&h.admin, &id);
+
+    assert!(!h.client.check_proof(&id, &proof_old, &inputs));
+    assert!(h.client.check_proof(&id, &proof_new, &inputs));
+}

--- a/contracts/zk_metadata_verifier/src/test/verification_tests.rs
+++ b/contracts/zk_metadata_verifier/src/test/verification_tests.rs
@@ -1,0 +1,433 @@
+//! End-to-end `verify_metadata`: the path a real issuer takes.
+
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address};
+
+use super::{scenario, START_LEDGER, VALIDITY_WINDOW};
+use crate::errors::Error;
+use crate::policy::VERDICT_SAFE;
+
+#[test]
+fn happy_path_issues_an_attestation() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 1);
+    let proof = s.proof(&signals);
+
+    let att = s.h.client.verify_metadata(&issuer, &proof, &signals);
+
+    assert_eq!(att.metadata_commitment, signals.metadata_commitment);
+    assert_eq!(att.issuer, issuer);
+    assert_eq!(att.risk_score, 42);
+    assert_eq!(att.policy_version, 1);
+    assert_eq!(att.verified_at, START_LEDGER);
+    assert!(!att.consumed);
+    assert_eq!(att.consumer, None);
+}
+
+#[test]
+fn attestation_is_readable_afterwards() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 2);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    let status = s.h.client.attestation_status(&signals.metadata_commitment);
+    assert!(status.exists);
+    assert!(status.valid);
+    assert!(!status.consumed);
+    assert!(!status.expired);
+    assert_eq!(status.risk_score, 42);
+}
+
+#[test]
+fn nullifier_is_spent_and_blocks_replay() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 3);
+    let proof = s.proof(&signals);
+
+    assert!(!s.h.client.is_nullifier_spent(&signals.nullifier));
+    s.h.client.verify_metadata(&issuer, &proof, &signals);
+    assert!(s.h.client.is_nullifier_spent(&signals.nullifier));
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::NullifierAlreadyUsed);
+}
+
+#[test]
+fn a_second_valid_proof_of_the_same_statement_is_still_blocked() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 4);
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+
+    // Groth16 is randomized: a prover can always mint a fresh, equally valid
+    // proof of the same claim. Replay protection therefore has to key on the
+    // nullifier, not on the proof bytes — this test is what proves it does.
+    let inputs = crate::policy::signals_to_public_inputs(&s.h.env, &signals);
+    let different_proof = super::fixtures::synth_proof(&s.h.env, &s.trapdoor, &inputs, 4242);
+    assert_ne!(different_proof.c, s.proof(&signals).c);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &different_proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::NullifierAlreadyUsed);
+}
+
+#[test]
+fn another_issuer_cannot_redeem_someone_elses_proof() {
+    let s = scenario();
+    let alice = s.h.issuer.clone();
+    let mallory = Address::generate(&s.h.env);
+
+    let signals = s.signals(&alice, 5);
+    let proof = s.proof(&signals);
+
+    // The proof is valid and unspent. The only thing stopping Mallory is that
+    // the circuit committed to Alice's issuer hash.
+    let err =
+        s.h.client
+            .try_verify_metadata(&mallory, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::IssuerBindingMismatch);
+
+    assert!(s
+        .h
+        .client
+        .try_verify_metadata(&alice, &proof, &signals)
+        .is_ok());
+}
+
+#[test]
+fn rejected_verdict_is_refused_even_with_a_valid_proof() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 6);
+    signals.verdict = 0;
+    let proof = s.proof(&signals);
+
+    // The proof correctly attests "the classifier said unsafe". Verifying it
+    // is not the same as accepting it.
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::VerdictRejected);
+}
+
+#[test]
+fn score_above_the_threshold_is_refused() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 7);
+    signals.risk_score = 251; // policy allows 250
+    let proof = s.proof(&signals);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::RiskScoreTooHigh);
+}
+
+#[test]
+fn score_exactly_at_the_threshold_is_accepted() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 8);
+    signals.risk_score = 250;
+    s.h.client
+        .verify_metadata(&issuer, &s.proof(&signals), &signals);
+    assert_eq!(
+        s.h.client
+            .get_attestation(&signals.metadata_commitment)
+            .risk_score,
+        250
+    );
+}
+
+#[test]
+fn stale_policy_root_is_refused() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 9);
+    signals.policy_root = super::digest32(&s.h.env, 0xEE);
+    let proof = s.proof(&signals);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::PolicyRootMismatch);
+}
+
+#[test]
+fn wrong_model_commitment_is_refused() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 10);
+    signals.model_commitment = super::digest32(&s.h.env, 0xDD);
+    let proof = s.proof(&signals);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::ModelCommitmentMismatch);
+}
+
+#[test]
+fn expired_proof_is_refused() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 11);
+    let proof = s.proof(&signals);
+
+    s.h.env
+        .ledger()
+        .with_mut(|l| l.sequence_number = signals.expiry_ledger + 1);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::ProofExpired);
+}
+
+#[test]
+fn overlong_validity_window_is_refused() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 12);
+    signals.expiry_ledger = START_LEDGER + VALIDITY_WINDOW + 1;
+    let proof = s.proof(&signals);
+
+    // An issuer must not be able to mint a proof that stays redeemable for a
+    // year; the policy caps how far ahead `expiry_ledger` may point.
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::ExpiryTooDistant);
+}
+
+#[test]
+fn tampering_with_signals_invalidates_the_proof() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 13);
+    let proof = s.proof(&signals);
+
+    // Change a field the policy checks do *not* pin, so the failure has to come
+    // from the pairing itself.
+    let mut tampered = signals.clone();
+    tampered.metadata_commitment = super::digest32(&s.h.env, 0x7F);
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &tampered)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::ProofVerificationFailed);
+}
+
+#[test]
+fn lowering_the_score_in_the_signals_invalidates_the_proof() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let mut signals = s.signals(&issuer, 14);
+    signals.risk_score = 900;
+    let proof = s.proof(&signals);
+
+    // A submitter who is over the threshold cannot simply edit the number down:
+    // `risk_score` is a public input, so the proof stops verifying.
+    let mut cheated = signals.clone();
+    cheated.risk_score = 10;
+
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &cheated)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::ProofVerificationFailed);
+}
+
+#[test]
+fn statistics_count_only_what_survives() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+
+    let good = s.signals(&issuer, 15);
+    s.h.client.verify_metadata(&issuer, &s.proof(&good), &good);
+
+    // A failed verification writes nothing at all — not even a rejection
+    // counter — because the failing invocation is rolled back wholesale.
+    let mut bad = s.signals(&issuer, 16);
+    let proof = s.proof(&bad);
+    bad.metadata_commitment = super::digest32(&s.h.env, 0x6F);
+    assert!(s
+        .h
+        .client
+        .try_verify_metadata(&issuer, &proof, &bad)
+        .is_err());
+
+    let stats = s.h.client.get_stats();
+    assert_eq!(stats.proofs_verified, 1);
+    assert_eq!(stats.attestations_issued, 1);
+    assert_eq!(stats.nullifiers_spent, 1);
+    assert!(!s.h.client.is_nullifier_spent(&bad.nullifier));
+}
+
+#[test]
+fn circuit_verification_counter_increments() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    for n in 20..23u8 {
+        let sig = s.signals(&issuer, n);
+        s.h.client.verify_metadata(&issuer, &s.proof(&sig), &sig);
+    }
+    assert_eq!(
+        s.h.client
+            .get_circuit(&super::METADATA_CIRCUIT)
+            .verifications,
+        3
+    );
+}
+
+#[test]
+fn issuer_counter_increments() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    assert_eq!(s.h.client.issuer_attestation_count(&issuer), 0);
+    for n in 30..32u8 {
+        let sig = s.signals(&issuer, n);
+        s.h.client.verify_metadata(&issuer, &s.proof(&sig), &sig);
+    }
+    assert_eq!(s.h.client.issuer_attestation_count(&issuer), 2);
+}
+
+#[test]
+fn pause_blocks_verification() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 40);
+    let proof = s.proof(&signals);
+
+    s.h.client.pause(&s.h.admin);
+    let err =
+        s.h.client
+            .try_verify_metadata(&issuer, &proof, &signals)
+            .err()
+            .unwrap()
+            .unwrap();
+    assert_eq!(err, Error::Paused);
+
+    s.h.client.unpause(&s.h.admin);
+    assert!(s
+        .h
+        .client
+        .try_verify_metadata(&issuer, &proof, &signals)
+        .is_ok());
+}
+
+#[test]
+fn signal_encoding_matches_the_declared_order() {
+    let s = scenario();
+    let issuer = s.h.issuer.clone();
+    let signals = s.signals(&issuer, 41);
+    let encoded = s.h.client.encode_signals(&signals);
+
+    assert_eq!(encoded.len(), super::METADATA_ARITY);
+    assert_eq!(
+        encoded.get_unchecked(0),
+        crate::field::u32_to_scalar_bytes(&s.h.env, VERDICT_SAFE)
+    );
+    assert_eq!(
+        encoded.get_unchecked(1),
+        crate::field::u32_to_scalar_bytes(&s.h.env, 42)
+    );
+    assert_eq!(encoded.get_unchecked(2), signals.policy_root);
+    assert_eq!(encoded.get_unchecked(3), signals.model_commitment);
+    assert_eq!(encoded.get_unchecked(4), signals.metadata_commitment);
+    assert_eq!(encoded.get_unchecked(5), signals.issuer_hash);
+    assert_eq!(encoded.get_unchecked(6), signals.nullifier);
+    assert_eq!(
+        encoded.get_unchecked(7),
+        crate::field::u32_to_scalar_bytes(&s.h.env, signals.expiry_ledger)
+    );
+}
+
+#[test]
+fn issuer_hash_is_deterministic_and_per_address() {
+    let s = scenario();
+    let a = Address::generate(&s.h.env);
+    let b = Address::generate(&s.h.env);
+    assert_eq!(
+        s.h.client.compute_issuer_hash(&a),
+        s.h.client.compute_issuer_hash(&a)
+    );
+    assert_ne!(
+        s.h.client.compute_issuer_hash(&a),
+        s.h.client.compute_issuer_hash(&b)
+    );
+    // The hash is fed to the circuit as a field element, so it must be
+    // canonical or the verifier would reject every honest proof.
+    assert!(s
+        .h
+        .client
+        .is_canonical_scalar(&s.h.client.compute_issuer_hash(&a)));
+}
+
+#[test]
+fn verify_metadata_without_a_policy_fails_cleanly() {
+    let h = super::setup();
+    let (vk, td) = super::fixtures::synth_vk(&h.env, super::METADATA_ARITY, 0);
+    super::register(&h, &super::METADATA_CIRCUIT, &vk, super::METADATA_ARITY);
+
+    let signals = crate::types::MetadataSignals {
+        verdict: 1,
+        risk_score: 1,
+        policy_root: super::digest32(&h.env, 1),
+        model_commitment: super::digest32(&h.env, 2),
+        metadata_commitment: super::digest32(&h.env, 3),
+        issuer_hash: h.client.compute_issuer_hash(&h.issuer),
+        nullifier: super::digest32(&h.env, 4),
+        expiry_ledger: START_LEDGER + 100,
+    };
+    let inputs = crate::policy::signals_to_public_inputs(&h.env, &signals);
+    let proof = super::fixtures::synth_proof(&h.env, &td, &inputs, 1);
+
+    let err = h
+        .client
+        .try_verify_metadata(&h.issuer, &proof, &signals)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyNotFound);
+}

--- a/contracts/zk_metadata_verifier/src/types.rs
+++ b/contracts/zk_metadata_verifier/src/types.rs
@@ -1,0 +1,340 @@
+//! On-chain data model for Groth16 verification and AI metadata attestation.
+//!
+//! ## Encoding conventions
+//!
+//! All curve points use the **uncompressed** big-endian serialization that the
+//! Soroban BLS12-381 host functions expect:
+//!
+//! * `G1` — 96 bytes: `be(X) || be(Y)`, each coordinate a 48-byte `Fp`.
+//! * `G2` — 192 bytes: `be(X_c1) || be(X_c0) || be(Y_c1) || be(Y_c0)`.
+//!
+//! The top three bits of the first byte are flag bits (compression, infinity,
+//! sort). Only the infinity flag may be set, and only on an otherwise-zero
+//! encoding.
+//!
+//! Scalars (`Fr`) are 32-byte big-endian integers that MUST be strictly less
+//! than the group order `r`. Non-canonical encodings are rejected rather than
+//! silently reduced, because reduction would make proofs malleable: two
+//! distinct byte strings would verify against the same statement.
+
+use soroban_sdk::{contracttype, Address, BytesN, Env, String, Symbol, Vec};
+
+/// Serialized G1 point (uncompressed, 96 bytes).
+pub type G1Bytes = BytesN<96>;
+/// Serialized G2 point (uncompressed, 192 bytes).
+pub type G2Bytes = BytesN<192>;
+/// Serialized `Fr` scalar (big-endian, 32 bytes).
+pub type ScalarBytes = BytesN<32>;
+/// A 32-byte domain digest (Poseidon or SHA-256 depending on context).
+pub type Digest = BytesN<32>;
+
+// ---------------------------------------------------------------------------
+// Proof material
+// ---------------------------------------------------------------------------
+
+/// A Groth16 proof: `(A ∈ G1, B ∈ G2, C ∈ G1)`.
+///
+/// This is the canonical `snarkjs` / `arkworks` triple. Nothing else from the
+/// prover is trusted — the statement lives entirely in the public inputs.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Groth16Proof {
+    /// `A` — first G1 element of the proof.
+    pub a: G1Bytes,
+    /// `B` — the single G2 element of the proof.
+    pub b: G2Bytes,
+    /// `C` — second G1 element of the proof.
+    pub c: G1Bytes,
+}
+
+/// A Groth16 verifying key for a fixed circuit.
+///
+/// `ic` holds the public-input commitment bases: `ic[0]` is the constant term
+/// and `ic[i]` pairs with public input `i - 1`. Therefore
+/// `ic.len() == num_public_inputs + 1` always.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifyingKey {
+    /// `α ∈ G1`.
+    pub alpha_g1: G1Bytes,
+    /// `β ∈ G2`.
+    pub beta_g2: G2Bytes,
+    /// `γ ∈ G2`.
+    pub gamma_g2: G2Bytes,
+    /// `δ ∈ G2`.
+    pub delta_g2: G2Bytes,
+    /// Public input bases `IC[0..=n]`.
+    pub ic: Vec<G1Bytes>,
+}
+
+/// Registry record wrapping a verifying key with its governance metadata.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CircuitRecord {
+    /// Stable identifier, e.g. `metadata_v1`.
+    pub circuit_id: Symbol,
+    /// The active verifying key.
+    pub vk: VerifyingKey,
+    /// Number of public inputs the circuit exposes (excludes the `IC[0]` term).
+    pub num_public_inputs: u32,
+    /// SHA-256 over the canonical VK serialization; the value operators audit.
+    pub vk_digest: Digest,
+    /// Human-readable provenance string (circuit source commit, ptau ceremony).
+    pub provenance: String,
+    /// When `false`, verification against this circuit is refused.
+    pub enabled: bool,
+    /// When `true`, the key can never be rotated again.
+    pub frozen: bool,
+    /// Monotonic counter incremented on every successful rotation.
+    pub revision: u32,
+    /// Ledger sequence at which the current key became active.
+    pub activated_at: u32,
+    /// Total successful verifications served by this circuit.
+    pub verifications: u64,
+}
+
+/// A verifying-key rotation awaiting its timelock.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingRotation {
+    /// Circuit being rotated.
+    pub circuit_id: Symbol,
+    /// The key that will become active once the timelock elapses.
+    pub vk: VerifyingKey,
+    /// Arity of the incoming key.
+    pub num_public_inputs: u32,
+    /// Digest of the incoming key, published up-front for auditors.
+    pub vk_digest: Digest,
+    /// Earliest ledger at which `finalize_rotation` may be called.
+    pub eta: u32,
+    /// Who proposed the rotation.
+    pub proposer: Address,
+}
+
+// ---------------------------------------------------------------------------
+// AI safety policy
+// ---------------------------------------------------------------------------
+
+/// The on-chain half of the AI safety policy.
+///
+/// The circuit enforces the *structure* of validation; this record pins the
+/// *parameters* that structure is evaluated against. Both halves are bound
+/// together by `policy_root`, which the circuit exposes as a public signal.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Policy {
+    /// Monotonically increasing version number.
+    pub version: u32,
+    /// Merkle root over the policy's rule set: blocklist root, term weights,
+    /// character-class tables and thresholds. The circuit proves the metadata
+    /// was evaluated against exactly this root.
+    pub policy_root: Digest,
+    /// Commitment to the scoring model (architecture hash + weight digest +
+    /// quantization scheme). Prevents a stale or rogue model from producing
+    /// accepted attestations.
+    pub model_commitment: Digest,
+    /// Inclusive upper bound on `risk_score` for an accepted attestation.
+    /// Scores are integers on a 0..=`risk_scale` axis.
+    pub max_risk_score: u32,
+    /// Denominator for `risk_score`, e.g. `1000` for per-mille granularity.
+    pub risk_scale: u32,
+    /// Maximum number of ledgers a proof may claim as its validity window.
+    pub max_validity_ledgers: u32,
+    /// Circuit that proofs must be verified against under this policy.
+    pub circuit_id: Symbol,
+    /// Ledger at which this policy became active.
+    pub activated_at: u32,
+    /// Free-form pointer to the published rule text (IPFS CID, URL, ...).
+    pub rulebook_uri: String,
+}
+
+/// Parameters accepted by `publish_policy`. Split from [`Policy`] so callers
+/// cannot forge `activated_at`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyParams {
+    pub version: u32,
+    pub policy_root: Digest,
+    pub model_commitment: Digest,
+    pub max_risk_score: u32,
+    pub risk_scale: u32,
+    pub max_validity_ledgers: u32,
+    pub circuit_id: Symbol,
+    pub rulebook_uri: String,
+}
+
+// ---------------------------------------------------------------------------
+// Public signals
+// ---------------------------------------------------------------------------
+
+/// The public signals of the `metadata_validator` circuit, in the exact order
+/// the circuit declares them.
+///
+/// ```text
+/// signal output verdict;              // 0
+/// signal output riskScore;            // 1
+/// signal input  policyRoot;           // 2
+/// signal input  modelCommitment;      // 3
+/// signal input  metadataCommitment;   // 4
+/// signal input  issuerHash;           // 5
+/// signal input  nullifier;            // 6
+/// signal input  expiryLedger;         // 7
+/// ```
+///
+/// Any change to this ordering is a breaking change to the circuit and must be
+/// accompanied by a new `circuit_id`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MetadataSignals {
+    /// `1` when the circuit concluded the metadata is safe, `0` otherwise.
+    /// The contract additionally refuses `0`, so a rejected verdict can never
+    /// produce an attestation even if a caller submits a valid proof of it.
+    pub verdict: u32,
+    /// Aggregate risk score on the policy's `risk_scale`.
+    pub risk_score: u32,
+    /// Must equal the active policy's `policy_root`.
+    pub policy_root: Digest,
+    /// Must equal the active policy's `model_commitment`.
+    pub model_commitment: Digest,
+    /// Poseidon commitment to the token metadata payload.
+    pub metadata_commitment: Digest,
+    /// `Poseidon(issuer_address_bytes)` — binds the proof to one issuer.
+    pub issuer_hash: Digest,
+    /// `Poseidon(metadata_commitment, issuer_hash, nonce)` — spent on use.
+    pub nullifier: Digest,
+    /// Ledger sequence after which this proof is stale.
+    pub expiry_ledger: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Attestations
+// ---------------------------------------------------------------------------
+
+/// The receipt written when a metadata proof verifies.
+///
+/// The mint lifecycle reads this instead of re-running the pairing check, so a
+/// single expensive verification amortizes across token creation and the first
+/// mint.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    /// Poseidon commitment to the metadata that was validated.
+    pub metadata_commitment: Digest,
+    /// The address the proof was bound to.
+    pub issuer: Address,
+    /// Nullifier that was spent to create this attestation.
+    pub nullifier: Digest,
+    /// Policy version in force at verification time.
+    pub policy_version: u32,
+    /// Circuit the proof was checked against.
+    pub circuit_id: Symbol,
+    /// Risk score carried by the proof.
+    pub risk_score: u32,
+    /// Ledger at which the attestation was created.
+    pub verified_at: u32,
+    /// Ledger after which the attestation may no longer be consumed.
+    pub expires_at: u32,
+    /// Set once a lifecycle contract has redeemed it.
+    pub consumed: bool,
+    /// Which contract consumed it, if any.
+    pub consumer: Option<Address>,
+    /// Ledger at which it was consumed, if it was.
+    pub consumed_at: Option<u32>,
+}
+
+/// Compact view returned by read-only queries that do not need the full record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttestationStatus {
+    pub exists: bool,
+    pub valid: bool,
+    pub consumed: bool,
+    pub expired: bool,
+    pub risk_score: u32,
+    pub policy_version: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Roles & configuration
+// ---------------------------------------------------------------------------
+
+/// Capabilities that can be granted independently of the root admin.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Role {
+    /// Full control, including role management and upgrades.
+    Admin,
+    /// May publish and activate safety policies.
+    PolicyAdmin,
+    /// May register, rotate, freeze and disable circuits.
+    CircuitAdmin,
+    /// May pause the contract (but not unpause — that stays with Admin).
+    Pauser,
+    /// A lifecycle contract permitted to consume attestations.
+    Consumer,
+}
+
+/// Instance-level configuration, set at initialization and tunable by Admin.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Config {
+    /// Ledgers a verifying-key rotation must wait before it can be finalized.
+    pub rotation_timelock: u32,
+    /// How long spent nullifiers are retained before they may be pruned.
+    /// Must exceed the maximum proof validity window or replay becomes
+    /// possible across the gap.
+    pub nullifier_ttl: u32,
+    /// Ledgers an unconsumed attestation is retained.
+    pub attestation_ttl: u32,
+    /// Hard cap on proofs per batch call.
+    pub max_batch_size: u32,
+    /// When true, `verify_metadata` requires `issuer.require_auth()`.
+    pub require_issuer_auth: bool,
+}
+
+/// Aggregate counters, useful for dashboards and for detecting anomalies.
+///
+/// There is deliberately no "rejected" counter. A Soroban invocation that
+/// returns an error rolls back every state change it made, so a counter
+/// incremented on the failure path would always read zero — and an event
+/// emitted there would never be published. Rejection telemetry has to come
+/// from the transaction's own error code, which the ledger records anyway.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct Stats {
+    pub proofs_verified: u64,
+    pub attestations_issued: u64,
+    pub attestations_consumed: u64,
+    pub nullifiers_spent: u64,
+    pub batches_verified: u64,
+}
+
+impl Stats {
+    /// All counters at zero. Equivalent to `Stats::default()`; named for
+    /// readability at the initialization call site.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Result of a batch verification, reported per-proof when the aggregate check
+/// fails and a fallback individual pass is requested.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchOutcome {
+    /// True when the aggregate pairing check succeeded outright.
+    pub aggregate_ok: bool,
+    /// Number of proofs in the batch.
+    pub size: u32,
+    /// Indices that failed, populated only when a fallback pass ran.
+    pub failed: Vec<u32>,
+}
+
+/// Helper: build an empty [`BatchOutcome`].
+pub fn empty_outcome(env: &Env, size: u32, aggregate_ok: bool) -> BatchOutcome {
+    BatchOutcome {
+        aggregate_ok,
+        size,
+        failed: Vec::new(env),
+    }
+}

--- a/contracts/zk_mint_gateway/Cargo.toml
+++ b/contracts/zk_mint_gateway/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "soromint-zk-mint-gateway"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "ZK-gated token creation and minting lifecycle for SoroMint"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+# The verifier is a *dev* dependency on purpose. Linking its rlib into the
+# gateway would pull in its `#[contractimpl]` exports and produce duplicate
+# wasm symbols (`pause`, `unpause`, ...). At runtime the gateway reaches it
+# through the `#[contractclient]` interface in `verifier.rs` instead, which
+# needs no link-time coupling; the tests link it only to register a real
+# instance to call.
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soromint-zk-metadata-verifier = { path = "../zk_metadata_verifier", features = [
+    "testutils",
+] }

--- a/contracts/zk_mint_gateway/src/errors.rs
+++ b/contracts/zk_mint_gateway/src/errors.rs
@@ -1,0 +1,33 @@
+//! Gateway errors. Codes start at 200 so they never collide with the
+//! verifier's, which propagate through cross-contract calls unchanged.
+
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 200,
+    NotInitialized = 201,
+    Unauthorized = 202,
+    Paused = 203,
+    NotPaused = 204,
+    /// The metadata commitment does not match the token parameters supplied.
+    CommitmentMismatch = 210,
+    /// A token has already been created from this attestation.
+    TokenAlreadyCreated = 211,
+    /// No token is registered under this commitment.
+    TokenNotFound = 212,
+    /// The caller is not the issuer of record for this token.
+    NotTokenIssuer = 213,
+    /// Minting would exceed the supply cap the metadata committed to.
+    SupplyCapExceeded = 214,
+    /// The issuer has used up their allowance for the current window.
+    QuotaExceeded = 215,
+    /// Token parameters failed basic structural validation.
+    InvalidTokenParams = 216,
+    /// The mint amount was zero or negative.
+    InvalidAmount = 217,
+    /// The token has been administratively frozen.
+    TokenFrozen = 218,
+}

--- a/contracts/zk_mint_gateway/src/events.rs
+++ b/contracts/zk_mint_gateway/src/events.rs
@@ -1,0 +1,51 @@
+//! Gateway events.
+
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use crate::types::Digest;
+
+const GATEWAY: Symbol = symbol_short!("gateway");
+const TOKEN: Symbol = symbol_short!("token");
+
+pub fn initialized(env: &Env, admin: &Address, verifier: &Address) {
+    env.events().publish(
+        (GATEWAY, symbol_short!("init")),
+        (admin.clone(), verifier.clone()),
+    );
+}
+
+pub fn config_updated(env: &Env, by: &Address) {
+    env.events()
+        .publish((GATEWAY, symbol_short!("config")), by.clone());
+}
+
+pub fn paused(env: &Env, by: &Address) {
+    env.events()
+        .publish((GATEWAY, symbol_short!("paused")), by.clone());
+}
+
+pub fn unpaused(env: &Env, by: &Address) {
+    env.events()
+        .publish((GATEWAY, symbol_short!("unpaused")), by.clone());
+}
+
+pub fn token_created(env: &Env, commitment: &Digest, issuer: &Address, risk_score: u32) {
+    env.events().publish(
+        (TOKEN, symbol_short!("created"), commitment.clone()),
+        (issuer.clone(), risk_score),
+    );
+}
+
+pub fn minted(env: &Env, commitment: &Digest, to: &Address, amount: i128, total: i128) {
+    env.events().publish(
+        (TOKEN, symbol_short!("minted"), commitment.clone()),
+        (to.clone(), amount, total),
+    );
+}
+
+pub fn token_frozen(env: &Env, commitment: &Digest, frozen: bool, by: &Address) {
+    env.events().publish(
+        (TOKEN, symbol_short!("frozen"), commitment.clone()),
+        (frozen, by.clone()),
+    );
+}

--- a/contracts/zk_mint_gateway/src/gateway.rs
+++ b/contracts/zk_mint_gateway/src/gateway.rs
@@ -1,0 +1,300 @@
+//! Token creation and minting, gated on a ZK safety attestation.
+
+use soroban_sdk::{contract, contractimpl, xdr::ToXdr, Address, Bytes, BytesN, Env, Vec};
+
+use crate::errors::Error;
+use crate::events;
+use crate::storage;
+use crate::types::{Digest, GatewayConfig, IssuerQuota, TokenParams, TokenRecord};
+use crate::verifier::VerifierClient;
+
+/// Domain tag for the metadata commitment preimage.
+const COMMITMENT_DST: &[u8] = b"SOROMINT-ZK-TOKEN-METADATA-V1";
+
+/// Default tokens an issuer may create per window.
+pub const DEFAULT_TOKENS_PER_WINDOW: u32 = 5;
+/// Default window length (~1 day at 5-second ledgers).
+pub const DEFAULT_WINDOW_LEDGERS: u32 = 17_280;
+
+#[contract]
+pub struct ZkMintGateway;
+
+#[contractimpl]
+impl ZkMintGateway {
+    /// One-time setup binding this gateway to a verifier instance.
+    pub fn initialize(env: Env, admin: Address, verifier: Address) -> Result<(), Error> {
+        if storage::is_initialized(&env) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+
+        storage::set_admin(&env, &admin);
+        storage::set_config(
+            &env,
+            &GatewayConfig {
+                verifier: verifier.clone(),
+                tokens_per_window: DEFAULT_TOKENS_PER_WINDOW,
+                window_ledgers: DEFAULT_WINDOW_LEDGERS,
+            },
+        );
+        storage::set_paused(&env, false);
+        storage::mark_initialized(&env);
+        storage::bump_instance(&env);
+
+        events::initialized(&env, &admin, &verifier);
+        Ok(())
+    }
+
+    pub fn set_config(env: Env, caller: Address, config: GatewayConfig) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        storage::require_admin(&env, &caller)?;
+        if config.window_ledgers == 0 {
+            return Err(Error::InvalidTokenParams);
+        }
+        storage::set_config(&env, &config);
+        events::config_updated(&env, &caller);
+        Ok(())
+    }
+
+    pub fn pause(env: Env, caller: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        storage::require_admin(&env, &caller)?;
+        if storage::is_paused(&env) {
+            return Err(Error::Paused);
+        }
+        storage::set_paused(&env, true);
+        events::paused(&env, &caller);
+        Ok(())
+    }
+
+    pub fn unpause(env: Env, caller: Address) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        storage::require_admin(&env, &caller)?;
+        if !storage::is_paused(&env) {
+            return Err(Error::NotPaused);
+        }
+        storage::set_paused(&env, false);
+        events::unpaused(&env, &caller);
+        Ok(())
+    }
+
+    /// Create a token by redeeming a safety attestation.
+    ///
+    /// Three things must line up, and each guards a distinct hole:
+    ///
+    /// 1. **The commitment matches the parameters.** Recomputing the hash from
+    ///    `params` and comparing it to the attestation is what stops an issuer
+    ///    from proving a bland payload safe and then deploying a different one.
+    /// 2. **The verifier consumes the attestation.** That cross-contract call
+    ///    marks it spent, so one proof yields one token.
+    /// 3. **The issuer is within quota.** A valid proof is not an unlimited
+    ///    deployment licence.
+    pub fn create_token(
+        env: Env,
+        issuer: Address,
+        params: TokenParams,
+        metadata_commitment: Digest,
+    ) -> Result<TokenRecord, Error> {
+        storage::require_initialized(&env)?;
+        storage::require_not_paused(&env)?;
+        issuer.require_auth();
+        storage::bump_instance(&env);
+
+        validate_params(&params)?;
+
+        if compute_commitment(&env, &issuer, &params) != metadata_commitment {
+            return Err(Error::CommitmentMismatch);
+        }
+        if storage::has_token(&env, &metadata_commitment) {
+            return Err(Error::TokenAlreadyCreated);
+        }
+
+        let config = storage::get_config(&env)?;
+        charge_quota(&env, &issuer, &config)?;
+
+        // Redeeming through the verifier is what makes the attestation
+        // single-use; the gateway never decides that for itself.
+        let verifier = VerifierClient::new(&env, &config.verifier);
+        let attestation = verifier.consume_attestation(
+            &env.current_contract_address(),
+            &metadata_commitment,
+            &issuer,
+        );
+
+        let record = TokenRecord {
+            metadata_commitment: metadata_commitment.clone(),
+            issuer: issuer.clone(),
+            params,
+            minted: 0,
+            created_at: env.ledger().sequence(),
+            policy_version: attestation.policy_version,
+            risk_score: attestation.risk_score,
+            frozen: false,
+        };
+
+        storage::set_token(&env, &record);
+        storage::push_token_index(&env, &metadata_commitment);
+        events::token_created(&env, &metadata_commitment, &issuer, record.risk_score);
+
+        Ok(record)
+    }
+
+    /// Mint supply against an already-created token.
+    ///
+    /// No proof is needed here: the metadata was screened once at creation and
+    /// has not changed. What is enforced is the supply cap the issuer committed
+    /// to inside the circuit — so the cap is as unforgeable as the name was.
+    pub fn mint(
+        env: Env,
+        issuer: Address,
+        metadata_commitment: Digest,
+        to: Address,
+        amount: i128,
+    ) -> Result<i128, Error> {
+        storage::require_initialized(&env)?;
+        storage::require_not_paused(&env)?;
+        issuer.require_auth();
+
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let mut record = storage::get_token(&env, &metadata_commitment)?;
+        if record.issuer != issuer {
+            return Err(Error::NotTokenIssuer);
+        }
+        if record.frozen {
+            return Err(Error::TokenFrozen);
+        }
+
+        let total = record
+            .minted
+            .checked_add(amount)
+            .ok_or(Error::SupplyCapExceeded)?;
+        if total > record.params.supply_cap {
+            return Err(Error::SupplyCapExceeded);
+        }
+
+        record.minted = total;
+        storage::set_token(&env, &record);
+        events::minted(&env, &metadata_commitment, &to, amount, total);
+
+        Ok(total)
+    }
+
+    /// Freeze or unfreeze a token. Admin only.
+    pub fn set_token_frozen(
+        env: Env,
+        caller: Address,
+        metadata_commitment: Digest,
+        frozen: bool,
+    ) -> Result<(), Error> {
+        storage::require_initialized(&env)?;
+        storage::require_admin(&env, &caller)?;
+
+        let mut record = storage::get_token(&env, &metadata_commitment)?;
+        record.frozen = frozen;
+        storage::set_token(&env, &record);
+        events::token_frozen(&env, &metadata_commitment, frozen, &caller);
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------- reads
+
+    pub fn get_token(env: Env, metadata_commitment: Digest) -> Result<TokenRecord, Error> {
+        storage::get_token(&env, &metadata_commitment)
+    }
+
+    pub fn list_tokens(env: Env) -> Vec<Digest> {
+        storage::token_index(&env)
+    }
+
+    pub fn get_config(env: Env) -> Result<GatewayConfig, Error> {
+        storage::get_config(&env)
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        storage::get_admin(&env)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        storage::is_paused(&env)
+    }
+
+    pub fn get_quota(env: Env, issuer: Address) -> Option<IssuerQuota> {
+        storage::get_quota(&env, &issuer)
+    }
+
+    /// Recompute the metadata commitment.
+    ///
+    /// Provers call this to obtain the exact value to witness the circuit
+    /// with, rather than reimplementing the domain-separated encoding off
+    /// chain and discovering the mismatch only at redemption time.
+    pub fn compute_commitment(env: Env, issuer: Address, params: TokenParams) -> Digest {
+        compute_commitment(&env, &issuer, &params)
+    }
+}
+
+/// `SHA-256(dst || issuer || name || symbol || decimals || cap || uri)`,
+/// truncated into the scalar field.
+///
+/// Length prefixes matter: without them `("ab", "c")` and `("a", "bc")` would
+/// hash identically, letting an issuer swap a name fragment into the symbol
+/// while keeping the commitment intact.
+///
+/// The top byte is cleared so the digest is a canonical `Fr` element, matching
+/// what the circuit can accept as a public signal.
+fn compute_commitment(env: &Env, issuer: &Address, params: &TokenParams) -> Digest {
+    let mut buf = Bytes::new(env);
+    buf.extend_from_slice(COMMITMENT_DST);
+    append_field(&mut buf, &issuer.clone().to_xdr(env));
+    append_field(&mut buf, &params.name.clone().to_xdr(env));
+    append_field(&mut buf, &params.symbol.clone().to_xdr(env));
+    buf.extend_from_array(&params.decimals.to_be_bytes());
+    buf.extend_from_array(&params.supply_cap.to_be_bytes());
+    append_field(&mut buf, &params.metadata_uri.clone().to_xdr(env));
+
+    let digest = env.crypto().sha256(&buf);
+    let mut arr = digest.to_array();
+    arr[0] = 0;
+    BytesN::from_array(env, &arr)
+}
+
+fn append_field(buf: &mut Bytes, field: &Bytes) {
+    buf.extend_from_array(&field.len().to_be_bytes());
+    buf.append(field);
+}
+
+fn validate_params(params: &TokenParams) -> Result<(), Error> {
+    if params.name.is_empty() || params.symbol.is_empty() {
+        return Err(Error::InvalidTokenParams);
+    }
+    if params.decimals > 18 {
+        return Err(Error::InvalidTokenParams);
+    }
+    if params.supply_cap <= 0 {
+        return Err(Error::InvalidTokenParams);
+    }
+    Ok(())
+}
+
+/// Consume one unit of the issuer's rolling allowance.
+fn charge_quota(env: &Env, issuer: &Address, config: &GatewayConfig) -> Result<(), Error> {
+    let now = env.ledger().sequence();
+    let mut quota = storage::get_quota(env, issuer).unwrap_or(IssuerQuota {
+        window_start: now,
+        used: 0,
+    });
+
+    if now.saturating_sub(quota.window_start) >= config.window_ledgers {
+        quota.window_start = now;
+        quota.used = 0;
+    }
+    if quota.used >= config.tokens_per_window {
+        return Err(Error::QuotaExceeded);
+    }
+
+    quota.used += 1;
+    storage::set_quota(env, issuer, &quota);
+    Ok(())
+}

--- a/contracts/zk_mint_gateway/src/lib.rs
+++ b/contracts/zk_mint_gateway/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+//! # SoroMint ZK Mint Gateway
+//!
+//! The lifecycle half of the ZK metadata pipeline. Issuers cannot create a
+//! token or mint supply through this contract without a valid AI safety
+//! attestation from [`soromint_zk_metadata_verifier`].
+//!
+//! ## Why the gateway is separate from the verifier
+//!
+//! The verifier answers one question — "is this proof valid under the active
+//! policy?" — and nothing else. Keeping token deployment out of it means the
+//! cryptographic core can be frozen and audited on its own, while the lifecycle
+//! rules (quotas, which factory to call, what counts as a mint) stay mutable.
+//!
+//! ## The two-call shape
+//!
+//! `verify_metadata` on the verifier, then `create_token` here. Splitting them
+//! is what makes the gas fit: a Groth16 verification costs roughly 56M CPU
+//! instructions against Soroban's 100M transaction budget, leaving too little
+//! headroom to also deploy a contract in the same invocation. The attestation
+//! is the durable handoff between the two transactions.
+
+mod errors;
+mod events;
+mod gateway;
+mod storage;
+mod types;
+mod verifier;
+
+pub use errors::Error;
+pub use gateway::{ZkMintGateway, ZkMintGatewayClient};
+pub use types::{GatewayConfig, IssuerQuota, TokenParams, TokenRecord};
+pub use verifier::{Attestation, VerifierClient, VerifierInterface};
+
+#[cfg(test)]
+mod test;

--- a/contracts/zk_mint_gateway/src/storage.rs
+++ b/contracts/zk_mint_gateway/src/storage.rs
@@ -1,0 +1,141 @@
+//! Gateway storage.
+
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+use crate::errors::Error;
+use crate::types::{Digest, GatewayConfig, IssuerQuota, TokenRecord};
+
+pub const BUMP_AMOUNT: u32 = 518_400;
+pub const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT - 86_400;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Initialized,
+    Admin,
+    Config,
+    Paused,
+    Token(Digest),
+    TokenIndex,
+    Quota(Address),
+}
+
+pub fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+}
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Initialized)
+}
+
+pub fn mark_initialized(env: &Env) {
+    env.storage().instance().set(&DataKey::Initialized, &true);
+}
+
+pub fn require_initialized(env: &Env) -> Result<(), Error> {
+    if is_initialized(env) {
+        Ok(())
+    } else {
+        Err(Error::NotInitialized)
+    }
+}
+
+pub fn get_admin(env: &Env) -> Result<Address, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    caller.require_auth();
+    if &get_admin(env)? == caller {
+        Ok(())
+    } else {
+        Err(Error::Unauthorized)
+    }
+}
+
+pub fn get_config(env: &Env) -> Result<GatewayConfig, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)
+}
+
+pub fn set_config(env: &Env, config: &GatewayConfig) {
+    env.storage().instance().set(&DataKey::Config, config);
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&DataKey::Paused, &paused);
+}
+
+pub fn require_not_paused(env: &Env) -> Result<(), Error> {
+    if is_paused(env) {
+        Err(Error::Paused)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn get_token(env: &Env, commitment: &Digest) -> Result<TokenRecord, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Token(commitment.clone()))
+        .ok_or(Error::TokenNotFound)
+}
+
+pub fn has_token(env: &Env, commitment: &Digest) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::Token(commitment.clone()))
+}
+
+pub fn set_token(env: &Env, record: &TokenRecord) {
+    let key = DataKey::Token(record.metadata_commitment.clone());
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
+}
+
+pub fn token_index(env: &Env) -> Vec<Digest> {
+    env.storage()
+        .instance()
+        .get(&DataKey::TokenIndex)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn push_token_index(env: &Env, commitment: &Digest) {
+    let mut index = token_index(env);
+    index.push_back(commitment.clone());
+    env.storage().instance().set(&DataKey::TokenIndex, &index);
+}
+
+pub fn get_quota(env: &Env, issuer: &Address) -> Option<IssuerQuota> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Quota(issuer.clone()))
+}
+
+pub fn set_quota(env: &Env, issuer: &Address, quota: &IssuerQuota) {
+    let key = DataKey::Quota(issuer.clone());
+    env.storage().persistent().set(&key, quota);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
+}

--- a/contracts/zk_mint_gateway/src/test.rs
+++ b/contracts/zk_mint_gateway/src/test.rs
@@ -1,0 +1,601 @@
+//! Gateway tests, driving a real verifier instance end to end.
+
+extern crate std;
+
+use soroban_sdk::{
+    symbol_short, testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String,
+    Symbol, Vec,
+};
+
+use soromint_zk_metadata_verifier::{
+    Groth16Proof, MetadataSignals, PolicyParams, ScalarBytes, VerifyingKey, ZkMetadataVerifier,
+    ZkMetadataVerifierClient,
+};
+
+use crate::errors::Error;
+use crate::gateway::{ZkMintGateway, ZkMintGatewayClient};
+use crate::types::{Digest, TokenParams};
+
+const CIRCUIT: Symbol = symbol_short!("meta_v1");
+const ARITY: u32 = 8;
+const START_LEDGER: u32 = 100_000;
+const VALIDITY: u32 = 17_280;
+
+// ---------------------------------------------------------------------------
+// Synthetic Groth16 material
+//
+// Same construction as the verifier crate's fixtures: pick the discrete logs,
+// then solve for `B` so that `−ab + xy + lc + zd ≡ 0`. The resulting proof is
+// real as far as the pairing check is concerned.
+// ---------------------------------------------------------------------------
+
+const G1_GENERATOR: [u8; 96] = [
+    0x17, 0xf1, 0xd3, 0xa7, 0x31, 0x97, 0xd7, 0x94, 0x26, 0x95, 0x63, 0x8c, 0x4f, 0xa9, 0xac, 0x0f,
+    0xc3, 0x68, 0x8c, 0x4f, 0x97, 0x74, 0xb9, 0x05, 0xa1, 0x4e, 0x3a, 0x3f, 0x17, 0x1b, 0xac, 0x58,
+    0x6c, 0x55, 0xe8, 0x3f, 0xf9, 0x7a, 0x1a, 0xef, 0xfb, 0x3a, 0xf0, 0x0a, 0xdb, 0x22, 0xc6, 0xbb,
+    0x08, 0xb3, 0xf4, 0x81, 0xe3, 0xaa, 0xa0, 0xf1, 0xa0, 0x9e, 0x30, 0xed, 0x74, 0x1d, 0x8a, 0xe4,
+    0xfc, 0xf5, 0xe0, 0x95, 0xd5, 0xd0, 0x0a, 0xf6, 0x00, 0xdb, 0x18, 0xcb, 0x2c, 0x04, 0xb3, 0xed,
+    0xd0, 0x3c, 0xc7, 0x44, 0xa2, 0x88, 0x8a, 0xe4, 0x0c, 0xaa, 0x23, 0x29, 0x46, 0xc5, 0xe7, 0xe1,
+];
+
+const G2_GENERATOR: [u8; 192] = [
+    0x13, 0xe0, 0x2b, 0x60, 0x52, 0x71, 0x9f, 0x60, 0x7d, 0xac, 0xd3, 0xa0, 0x88, 0x27, 0x4f, 0x65,
+    0x59, 0x6b, 0xd0, 0xd0, 0x99, 0x20, 0xb6, 0x1a, 0xb5, 0xda, 0x61, 0xbb, 0xdc, 0x7f, 0x50, 0x49,
+    0x33, 0x4c, 0xf1, 0x12, 0x13, 0x94, 0x5d, 0x57, 0xe5, 0xac, 0x7d, 0x05, 0x5d, 0x04, 0x2b, 0x7e,
+    0x02, 0x4a, 0xa2, 0xb2, 0xf0, 0x8f, 0x0a, 0x91, 0x26, 0x08, 0x05, 0x27, 0x2d, 0xc5, 0x10, 0x51,
+    0xc6, 0xe4, 0x7a, 0xd4, 0xfa, 0x40, 0x3b, 0x02, 0xb4, 0x51, 0x0b, 0x64, 0x7a, 0xe3, 0xd1, 0x77,
+    0x0b, 0xac, 0x03, 0x26, 0xa8, 0x05, 0xbb, 0xef, 0xd4, 0x80, 0x56, 0xc8, 0xc1, 0x21, 0xbd, 0xb8,
+    0x06, 0x06, 0xc4, 0xa0, 0x2e, 0xa7, 0x34, 0xcc, 0x32, 0xac, 0xd2, 0xb0, 0x2b, 0xc2, 0x8b, 0x99,
+    0xcb, 0x3e, 0x28, 0x7e, 0x85, 0xa7, 0x63, 0xaf, 0x26, 0x74, 0x92, 0xab, 0x57, 0x2e, 0x99, 0xab,
+    0x3f, 0x37, 0x0d, 0x27, 0x5c, 0xec, 0x1d, 0xa1, 0xaa, 0xa9, 0x07, 0x5f, 0xf0, 0x5f, 0x79, 0xbe,
+    0x0c, 0xe5, 0xd5, 0x27, 0x72, 0x7d, 0x6e, 0x11, 0x8c, 0xc9, 0xcd, 0xc6, 0xda, 0x2e, 0x35, 0x1a,
+    0xad, 0xfd, 0x9b, 0xaa, 0x8c, 0xbd, 0xd3, 0xa7, 0x6d, 0x42, 0x9a, 0x69, 0x51, 0x60, 0xd1, 0x2c,
+    0x92, 0x3a, 0xc9, 0xcc, 0x3b, 0xac, 0xa2, 0x89, 0xe1, 0x93, 0x54, 0x86, 0x08, 0xb8, 0x28, 0x01,
+];
+
+use soroban_sdk::crypto::bls12_381::{Fr, G1Affine, G2Affine};
+
+fn fr(env: &Env, v: u32) -> Fr {
+    Fr::from_u256(soroban_sdk::U256::from_u32(env, v))
+}
+
+fn g1(env: &Env, s: &Fr) -> BytesN<96> {
+    env.crypto()
+        .bls12_381()
+        .g1_mul(&G1Affine::from_array(env, &G1_GENERATOR), s)
+        .to_bytes()
+}
+
+fn g2(env: &Env, s: &Fr) -> BytesN<192> {
+    env.crypto()
+        .bls12_381()
+        .g2_mul(&G2Affine::from_array(env, &G2_GENERATOR), s)
+        .to_bytes()
+}
+
+struct Trapdoor {
+    alpha: Fr,
+    beta: Fr,
+    gamma: Fr,
+    delta: Fr,
+    ic: std::vec::Vec<Fr>,
+}
+
+fn synth_vk(env: &Env) -> (VerifyingKey, Trapdoor) {
+    let alpha = fr(env, 7);
+    let beta = fr(env, 11);
+    let gamma = fr(env, 13);
+    let delta = fr(env, 17);
+
+    let mut ic_logs = std::vec::Vec::new();
+    let mut ic: Vec<BytesN<96>> = Vec::new(env);
+    for j in 0..=ARITY {
+        let log = fr(env, 101 + j * 3);
+        ic.push_back(g1(env, &log));
+        ic_logs.push(log);
+    }
+
+    (
+        VerifyingKey {
+            alpha_g1: g1(env, &alpha),
+            beta_g2: g2(env, &beta),
+            gamma_g2: g2(env, &gamma),
+            delta_g2: g2(env, &delta),
+            ic,
+        },
+        Trapdoor {
+            alpha,
+            beta,
+            gamma,
+            delta,
+            ic: ic_logs,
+        },
+    )
+}
+
+fn synth_proof(env: &Env, td: &Trapdoor, inputs: &Vec<ScalarBytes>) -> Groth16Proof {
+    let bls = env.crypto().bls12_381();
+    let mut l = td.ic[0].clone();
+    for j in 0..inputs.len() {
+        let x = Fr::from_bytes(inputs.get_unchecked(j));
+        l = bls.fr_add(&l, &bls.fr_mul(&td.ic[(j + 1) as usize], &x));
+    }
+    let z = fr(env, 31337);
+    let b = bls.fr_add(
+        &bls.fr_add(&bls.fr_mul(&td.alpha, &td.beta), &bls.fr_mul(&l, &td.gamma)),
+        &bls.fr_mul(&z, &td.delta),
+    );
+    Groth16Proof {
+        a: g1(env, &fr(env, 1)),
+        b: g2(env, &b),
+        c: g1(env, &z),
+    }
+}
+
+fn digest32(env: &Env, seed: u8) -> Digest {
+    let mut arr = [0u8; 32];
+    arr[31] = seed;
+    arr[30] = seed.wrapping_mul(7);
+    arr[17] = seed.wrapping_add(0x5a);
+    BytesN::from_array(env, &arr)
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+struct Rig<'a> {
+    env: Env,
+    verifier: ZkMetadataVerifierClient<'a>,
+    gateway: ZkMintGatewayClient<'a>,
+    admin: Address,
+    issuer: Address,
+    trapdoor: Trapdoor,
+    policy_root: Digest,
+    model: Digest,
+}
+
+fn setup() -> Rig<'static> {
+    let env = Env::default();
+    env.cost_estimate().budget().reset_unlimited();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = START_LEDGER);
+
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+
+    let verifier_id = env.register(ZkMetadataVerifier, ());
+    let verifier = ZkMetadataVerifierClient::new(&env, &verifier_id);
+    verifier.initialize(&admin);
+
+    let (vk, trapdoor) = synth_vk(&env);
+    verifier.register_circuit(
+        &admin,
+        &CIRCUIT,
+        &vk,
+        &ARITY,
+        &String::from_str(&env, "gateway-test"),
+    );
+
+    let policy_root = digest32(&env, 0x11);
+    let model = digest32(&env, 0x22);
+    let params = PolicyParams {
+        version: 1,
+        policy_root: policy_root.clone(),
+        model_commitment: model.clone(),
+        max_risk_score: 250,
+        risk_scale: 1000,
+        max_validity_ledgers: VALIDITY,
+        circuit_id: CIRCUIT,
+        rulebook_uri: String::from_str(&env, "ipfs://policy"),
+    };
+    verifier.publish_policy(&admin, &params);
+    verifier.activate_policy(&admin, &1);
+
+    let gateway_id = env.register(ZkMintGateway, ());
+    let gateway = ZkMintGatewayClient::new(&env, &gateway_id);
+    gateway.initialize(&admin, &verifier_id);
+    verifier.register_consumer(&admin, &gateway_id);
+
+    Rig {
+        env,
+        verifier,
+        gateway,
+        admin,
+        issuer,
+        trapdoor,
+        policy_root,
+        model,
+    }
+}
+
+impl Rig<'_> {
+    fn params(&self, name: &str, symbol: &str) -> TokenParams {
+        TokenParams {
+            name: String::from_str(&self.env, name),
+            symbol: String::from_str(&self.env, symbol),
+            decimals: 7,
+            supply_cap: 1_000_000,
+            metadata_uri: String::from_str(&self.env, "ipfs://token"),
+        }
+    }
+
+    /// Run the full off-chain-to-on-chain flow and return the commitment.
+    fn attest(&self, params: &TokenParams, nonce: u8) -> Digest {
+        let commitment = self.gateway.compute_commitment(&self.issuer, params);
+        let signals = MetadataSignals {
+            verdict: 1,
+            risk_score: 42,
+            policy_root: self.policy_root.clone(),
+            model_commitment: self.model.clone(),
+            metadata_commitment: commitment.clone(),
+            issuer_hash: self.verifier.compute_issuer_hash(&self.issuer),
+            nullifier: digest32(&self.env, 0x80 | nonce),
+            expiry_ledger: START_LEDGER + VALIDITY / 2,
+        };
+        let inputs = self.verifier.encode_signals(&signals);
+        let proof = synth_proof(&self.env, &self.trapdoor, &inputs);
+        self.verifier
+            .verify_metadata(&self.issuer, &proof, &signals);
+        commitment
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_flow_creates_a_token() {
+    let r = setup();
+    let params = r.params("Good Token", "GOOD");
+    let commitment = r.attest(&params, 1);
+
+    let record = r.gateway.create_token(&r.issuer, &params, &commitment);
+    assert_eq!(record.issuer, r.issuer);
+    assert_eq!(record.risk_score, 42);
+    assert_eq!(record.policy_version, 1);
+    assert_eq!(record.minted, 0);
+    assert!(!record.frozen);
+}
+
+#[test]
+fn creation_consumes_the_attestation() {
+    let r = setup();
+    let params = r.params("Once", "ONCE");
+    let commitment = r.attest(&params, 2);
+
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+    assert!(r.verifier.attestation_status(&commitment).consumed);
+
+    // The second attempt fails inside the verifier, not here — which is the
+    // point: the gateway does not get to decide single-use for itself.
+    assert!(r
+        .gateway
+        .try_create_token(&r.issuer, &params, &commitment)
+        .is_err());
+}
+
+#[test]
+fn creation_without_an_attestation_fails() {
+    let r = setup();
+    let params = r.params("Unproven", "NOPE");
+    let commitment = r.gateway.compute_commitment(&r.issuer, &params);
+
+    assert!(r
+        .gateway
+        .try_create_token(&r.issuer, &params, &commitment)
+        .is_err());
+}
+
+#[test]
+fn swapped_parameters_are_caught_by_the_commitment() {
+    let r = setup();
+    let clean = r.params("Clean Token", "CLEAN");
+    let commitment = r.attest(&clean, 3);
+
+    // The attestation covers "Clean Token"; deploying something else under it
+    // is exactly the substitution the commitment check exists to stop.
+    let nasty = r.params("Rug Pull", "SCAM");
+    let err = r
+        .gateway
+        .try_create_token(&r.issuer, &nasty, &commitment)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CommitmentMismatch);
+}
+
+#[test]
+fn another_issuer_cannot_use_the_commitment() {
+    let r = setup();
+    let params = r.params("Mine", "MINE");
+    let commitment = r.attest(&params, 4);
+
+    // The commitment binds the issuer, so recomputing it under a different
+    // address yields a different value and never matches.
+    let mallory = Address::generate(&r.env);
+    let err = r
+        .gateway
+        .try_create_token(&mallory, &params, &commitment)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CommitmentMismatch);
+}
+
+#[test]
+fn minting_respects_the_committed_supply_cap() {
+    let r = setup();
+    let params = r.params("Capped", "CAP");
+    let commitment = r.attest(&params, 5);
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+
+    assert_eq!(
+        r.gateway.mint(&r.issuer, &commitment, &r.issuer, &600_000),
+        600_000
+    );
+    assert_eq!(
+        r.gateway.mint(&r.issuer, &commitment, &r.issuer, &400_000),
+        1_000_000
+    );
+
+    let err = r
+        .gateway
+        .try_mint(&r.issuer, &commitment, &r.issuer, &1)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::SupplyCapExceeded);
+}
+
+#[test]
+fn only_the_issuer_can_mint() {
+    let r = setup();
+    let params = r.params("Owned", "OWN");
+    let commitment = r.attest(&params, 6);
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+
+    let stranger = Address::generate(&r.env);
+    let err = r
+        .gateway
+        .try_mint(&stranger, &commitment, &stranger, &1)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::NotTokenIssuer);
+}
+
+#[test]
+fn zero_and_negative_mints_are_rejected() {
+    let r = setup();
+    let params = r.params("Zero", "ZRO");
+    let commitment = r.attest(&params, 7);
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+
+    for amount in [0i128, -1i128] {
+        let err = r
+            .gateway
+            .try_mint(&r.issuer, &commitment, &r.issuer, &amount)
+            .err()
+            .unwrap()
+            .unwrap();
+        assert_eq!(err, Error::InvalidAmount);
+    }
+}
+
+#[test]
+fn frozen_token_cannot_mint() {
+    let r = setup();
+    let params = r.params("Frozen", "FRZ");
+    let commitment = r.attest(&params, 8);
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+
+    r.gateway.set_token_frozen(&r.admin, &commitment, &true);
+    let err = r
+        .gateway
+        .try_mint(&r.issuer, &commitment, &r.issuer, &1)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::TokenFrozen);
+
+    r.gateway.set_token_frozen(&r.admin, &commitment, &false);
+    assert_eq!(r.gateway.mint(&r.issuer, &commitment, &r.issuer, &1), 1);
+}
+
+#[test]
+fn quota_limits_creations_per_window() {
+    let r = setup();
+    let mut config = r.gateway.get_config();
+    config.tokens_per_window = 2;
+    r.gateway.set_config(&r.admin, &config);
+
+    for n in 10..12u8 {
+        let params = r.params("Quota", "QTA");
+        // Distinct URIs give distinct commitments.
+        let mut p = params.clone();
+        p.metadata_uri = String::from_str(&r.env, if n == 10 { "a" } else { "b" });
+        let commitment = r.attest(&p, n);
+        r.gateway.create_token(&r.issuer, &p, &commitment);
+    }
+
+    let mut p = r.params("Quota", "QTA");
+    p.metadata_uri = String::from_str(&r.env, "c");
+    let commitment = r.attest(&p, 12);
+    let err = r
+        .gateway
+        .try_create_token(&r.issuer, &p, &commitment)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::QuotaExceeded);
+}
+
+#[test]
+fn quota_resets_after_the_window() {
+    let r = setup();
+    let mut config = r.gateway.get_config();
+    config.tokens_per_window = 1;
+    r.gateway.set_config(&r.admin, &config);
+
+    let mut p1 = r.params("First", "ONE");
+    p1.metadata_uri = String::from_str(&r.env, "one");
+    let c1 = r.attest(&p1, 20);
+    r.gateway.create_token(&r.issuer, &p1, &c1);
+
+    r.env.ledger().with_mut(|l| {
+        l.sequence_number = START_LEDGER + config.window_ledgers + 1;
+    });
+
+    let mut p2 = r.params("Second", "TWO");
+    p2.metadata_uri = String::from_str(&r.env, "two");
+    // Re-attest at the new ledger so the proof is fresh.
+    let commitment = r.gateway.compute_commitment(&r.issuer, &p2);
+    let signals = MetadataSignals {
+        verdict: 1,
+        risk_score: 42,
+        policy_root: r.policy_root.clone(),
+        model_commitment: r.model.clone(),
+        metadata_commitment: commitment.clone(),
+        issuer_hash: r.verifier.compute_issuer_hash(&r.issuer),
+        nullifier: digest32(&r.env, 0xAB),
+        expiry_ledger: START_LEDGER + config.window_ledgers + 100,
+    };
+    let inputs = r.verifier.encode_signals(&signals);
+    let proof = synth_proof(&r.env, &r.trapdoor, &inputs);
+    r.verifier.verify_metadata(&r.issuer, &proof, &signals);
+
+    r.gateway.create_token(&r.issuer, &p2, &commitment);
+    assert_eq!(r.gateway.get_quota(&r.issuer).unwrap().used, 1);
+}
+
+#[test]
+fn invalid_params_are_rejected() {
+    let r = setup();
+    let mut p = r.params("", "SYM");
+    let c = r.gateway.compute_commitment(&r.issuer, &p);
+    assert_eq!(
+        r.gateway
+            .try_create_token(&r.issuer, &p, &c)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::InvalidTokenParams
+    );
+
+    p = r.params("Name", "SYM");
+    p.decimals = 19;
+    let c = r.gateway.compute_commitment(&r.issuer, &p);
+    assert_eq!(
+        r.gateway
+            .try_create_token(&r.issuer, &p, &c)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::InvalidTokenParams
+    );
+
+    p = r.params("Name", "SYM");
+    p.supply_cap = 0;
+    let c = r.gateway.compute_commitment(&r.issuer, &p);
+    assert_eq!(
+        r.gateway
+            .try_create_token(&r.issuer, &p, &c)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::InvalidTokenParams
+    );
+}
+
+#[test]
+fn commitment_is_field_separated() {
+    let r = setup();
+    // Without length prefixes, ("ab","c") and ("a","bc") would collide and an
+    // issuer could shuffle characters between name and symbol after screening.
+    let mut a = r.params("ab", "c");
+    a.metadata_uri = String::from_str(&r.env, "");
+    let mut b = r.params("a", "bc");
+    b.metadata_uri = String::from_str(&r.env, "");
+
+    assert_ne!(
+        r.gateway.compute_commitment(&r.issuer, &a),
+        r.gateway.compute_commitment(&r.issuer, &b)
+    );
+}
+
+#[test]
+fn pause_blocks_creation_and_minting() {
+    let r = setup();
+    let params = r.params("Pausable", "PAU");
+    let commitment = r.attest(&params, 30);
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+
+    r.gateway.pause(&r.admin);
+    assert_eq!(
+        r.gateway
+            .try_mint(&r.issuer, &commitment, &r.issuer, &1)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::Paused
+    );
+
+    r.gateway.unpause(&r.admin);
+    assert_eq!(r.gateway.mint(&r.issuer, &commitment, &r.issuer, &1), 1);
+}
+
+#[test]
+fn non_admin_cannot_freeze_or_configure() {
+    let r = setup();
+    let stranger = Address::generate(&r.env);
+    let params = r.params("Guarded", "GRD");
+    let commitment = r.attest(&params, 31);
+    r.gateway.create_token(&r.issuer, &params, &commitment);
+
+    assert_eq!(
+        r.gateway
+            .try_set_token_frozen(&stranger, &commitment, &true)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::Unauthorized
+    );
+
+    let config = r.gateway.get_config();
+    assert_eq!(
+        r.gateway
+            .try_set_config(&stranger, &config)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::Unauthorized
+    );
+}
+
+#[test]
+fn tokens_are_indexed() {
+    let r = setup();
+    for (n, uri) in [(40u8, "x"), (41u8, "y")] {
+        let mut p = r.params("Indexed", "IDX");
+        p.metadata_uri = String::from_str(&r.env, uri);
+        let c = r.attest(&p, n);
+        r.gateway.create_token(&r.issuer, &p, &c);
+    }
+    assert_eq!(r.gateway.list_tokens().len(), 2);
+}
+
+#[test]
+fn double_initialize_is_rejected() {
+    let r = setup();
+    let other = Address::generate(&r.env);
+    assert_eq!(
+        r.gateway
+            .try_initialize(&r.admin, &other)
+            .err()
+            .unwrap()
+            .unwrap(),
+        Error::AlreadyInitialized
+    );
+}

--- a/contracts/zk_mint_gateway/src/types.rs
+++ b/contracts/zk_mint_gateway/src/types.rs
@@ -1,0 +1,59 @@
+//! Gateway data model.
+
+use soroban_sdk::{contracttype, Address, BytesN, String};
+
+/// 32-byte commitment, matching the verifier's `Digest`.
+pub type Digest = BytesN<32>;
+
+/// The token parameters an issuer commits to inside the circuit.
+///
+/// These are hashed into `metadata_commitment`; the gateway recomputes that
+/// hash and refuses to proceed unless it matches the attestation. Without that
+/// step an issuer could prove a harmless payload safe and then deploy a
+/// different one.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenParams {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u32,
+    pub supply_cap: i128,
+    pub metadata_uri: String,
+}
+
+/// A token created through the gateway.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenRecord {
+    pub metadata_commitment: Digest,
+    pub issuer: Address,
+    pub params: TokenParams,
+    pub minted: i128,
+    pub created_at: u32,
+    pub policy_version: u32,
+    pub risk_score: u32,
+    pub frozen: bool,
+}
+
+/// Per-issuer throughput limit.
+///
+/// A valid proof is not a licence to deploy unlimited tokens; quotas bound the
+/// blast radius of a leaked prover key.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IssuerQuota {
+    pub window_start: u32,
+    pub used: u32,
+}
+
+/// Gateway configuration.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GatewayConfig {
+    /// Address of the deployed `ZkMetadataVerifier`.
+    pub verifier: Address,
+    /// Tokens an issuer may create per window.
+    pub tokens_per_window: u32,
+    /// Window length in ledgers.
+    pub window_ledgers: u32,
+}

--- a/contracts/zk_mint_gateway/src/verifier.rs
+++ b/contracts/zk_mint_gateway/src/verifier.rs
@@ -1,0 +1,44 @@
+//! The slice of the verifier's interface the gateway depends on.
+//!
+//! Declaring it as a `#[contractclient]` trait rather than importing the
+//! verifier crate keeps the two contracts decoupled at link time. Importing it
+//! would drag the verifier's exported entrypoints into the gateway's wasm and
+//! collide on every shared name.
+//!
+//! [`Attestation`] mirrors the verifier's struct field for field.
+//! `#[contracttype]` structs are encoded as maps keyed by field name, so a
+//! structurally identical mirror decodes a verifier response correctly. The
+//! integration tests assert exactly that by round-tripping a real attestation
+//! through this client.
+
+use soroban_sdk::{contractclient, contracttype, Address, BytesN, Env, Symbol};
+
+/// Mirror of `soromint_zk_metadata_verifier::Attestation`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    pub metadata_commitment: BytesN<32>,
+    pub issuer: Address,
+    pub nullifier: BytesN<32>,
+    pub policy_version: u32,
+    pub circuit_id: Symbol,
+    pub risk_score: u32,
+    pub verified_at: u32,
+    pub expires_at: u32,
+    pub consumed: bool,
+    pub consumer: Option<Address>,
+    pub consumed_at: Option<u32>,
+}
+
+#[contractclient(name = "VerifierClient")]
+pub trait VerifierInterface {
+    /// Redeem an attestation. Fails in the verifier if it is missing, already
+    /// consumed, expired, or bound to a different issuer — the gateway does
+    /// not re-check any of that, so single-use has exactly one owner.
+    fn consume_attestation(
+        env: Env,
+        consumer: Address,
+        metadata_commitment: BytesN<32>,
+        issuer: Address,
+    ) -> Attestation;
+}


### PR DESCRIPTION
## Decentralized AI Metadata Validation via On-Chain ZK Proof Verification

Closes #761

Replaces on-chain regex/string scanning with off-chain proving + on-chain Groth16 verification. Validation cost becomes constant (4 pairings) regardless of rule-set size, and the rule set stays private behind a Merkle commitment instead of being published as an evasion guide.

### What's added

**`contracts/zk_metadata_verifier`** — Groth16 verifier over BLS12-381 using Soroban's native curve host functions.

- Single 4-pair `pairing_check`: `e(−A,B)·e(α,β)·e(L,γ)·e(C,δ) = 1`
- Full point validation — encoding flags, coordinate range, **subgroup membership**
- Scalars rejected if `≥ r` rather than reduced (reduction makes proofs malleable)
- Batch verification: `4n` pairings → `n+3`, via Fiat–Shamir coefficients and a nested-MSM fold over the IC bases
- Timelocked verifying-key rotation, versioned safety policies, nullifier replay protection, attestation receipts

**`contracts/zk_mint_gateway`** — lifecycle integration. `create_token` recomputes the metadata commitment from the actual token params and redeems the attestation through the verifier; `mint` enforces the supply cap committed to inside the circuit.

### Measured cost

`verify_metadata` costs **~56.5M CPU instructions** against Soroban's 100M transaction limit. That headroom is why token creation is a second transaction rather than bundled in — there isn't room for both.

### Testing

**162 tests, all passing.** Fixtures build *genuine* satisfying Groth16 instances (choose the discrete logs, solve for `B` so `−ab + xy + lc + zd ≡ 0`), so every test exercises the real host pairing path — including wrong inputs, wrong key, swapped `A`/`C`, mismatched batch pairings, and non-canonical scalars.

### Notes for review

- **No rejection counter.** A failing Soroban call rolls back its own writes, so failure-path telemetry can never persist. Omitted rather than shipped as permanently-zero metrics.
- **Off-curve points trap in the host** instead of returning a clean error — the SDK exposes no `Fp` multiplication, so `y² = x³ + 4` can't be checked in-guest. Still rejected; documented and pinned by `#[should_panic]` tests.
- **G2 serialization is `X_c1‖X_c0‖Y_c1‖Y_c0`** — the `c1` component leads. This is the usual snarkjs porting bug: get it backwards and the point is still on-curve and in-subgroup, only the pairing disagrees.

### Not included

The Circom circuit and off-chain prover CLI. The contract pins the interface they must hit: public-signal order in `policy.rs`, plus `compute_issuer_hash` / `compute_commitment` exposed on-chain so provers don't reimplement the hashing and get it subtly wrong.

### Checks

`cargo build` (native + wasm release) · `cargo test` (162 pass) · `cargo clippy --all-targets` (0 warnings) · `cargo fmt --check` — all green.
