### PR TITLE
feat: add Compliance dashboard UI with blacklist and clawback audit tables (Closes #733)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,6 +17,7 @@ import {
   ScrollText,
   ArrowLeftRight,
   Factory,
+  Scale,
 } from "lucide-react";
 
 // UI Components & Stores
@@ -31,6 +32,7 @@ const VotingDashboard = lazy(() => import("./components/VotingDashboard"));
 const MultisigDashboard = lazy(() => import("./pages/Multisig/Multisig"));
 const BackstopDashboard = lazy(() => import("./pages/Backstop/Backstop"));
 const ZKAuditLogDashboard = lazy(() => import("./pages/ZKAuditLog/ZKAuditLog"));
+const ComplianceDashboard = lazy(() => import("./pages/Compliance/Compliance"));
 const BridgeReceiverDashboard = lazy(() =>
   import("./components/BridgeReceiverDashboard")
 );
@@ -47,6 +49,7 @@ const views = [
   { id: "multisig", label: "Multisig", icon: Users },
   { id: "backstop", label: "Backstop", icon: ShieldCheck },
   { id: "audit-log", label: "Audit Log", icon: ScrollText },
+  { id: "compliance", label: "Compliance", icon: Scale },
 ];
 
 /**
@@ -473,6 +476,32 @@ function App() {
             <MultisigDashboard />
             <BackstopDashboard />
             <ZKAuditLogDashboard />
+          </ErrorBoundary>
+        </Suspense>
+      ) : activeView === "compliance" ? (
+        <Suspense
+          fallback={
+            <div className="glass-card flex min-h-[320px] items-center justify-center">
+              <div className="space-y-3 text-center">
+                <p className="text-sm uppercase tracking-[0.3em] text-emerald-500">
+                  Compliance
+                </p>
+                <p className="text-lg font-medium dark:text-white">
+                  Loading compliance status…
+                </p>
+              </div>
+            </div>
+          }
+        >
+          <ErrorBoundary
+            fallbackRender={({ resetErrorBoundary }) => (
+              <SectionCrashCard
+                title="Compliance Unavailable"
+                onRetry={resetErrorBoundary}
+              />
+            )}
+          >
+            <ComplianceDashboard />
           </ErrorBoundary>
         </Suspense>
       ) : (

--- a/client/src/locales/ar/translation.json
+++ b/client/src/locales/ar/translation.json
@@ -100,6 +100,7 @@
       "rejected": "مرفوض",
       "signers": "الموقّعون"
     }
+  },
   "nav": {
     "dashboard": "لوحة التحكم",
     "governance": "الحوكمة",
@@ -178,6 +179,43 @@
       "successful": "ناجحة",
       "failed": "فاشلة",
       "rate": "نسبة النجاح"
+    }
+  },
+  "compliance": {
+    "pageTitle": "الامتثال",
+    "pageSubtitle": "إدارة القائمة السوداء وسجلات تدقيق الاسترداد لامتثال العملات",
+    "badge": "القائمة السوداء والاسترداد",
+    "refreshButton": "تحديث",
+    "demoMode": "وضع تجريبي — بيانات وهمية",
+    "demoHint": "وضع تجريبي — الخادم الخلفي غير متصل. تُعرض بيانات وهمية.",
+    "fetchError": "فشل تحميل بيانات الامتثال",
+    "configTitle": "إعدادات العقد",
+    "admin": "المسؤول",
+    "clawbackAdmin": "مسؤول الاسترداد",
+    "tokenAddress": "عقد العملة",
+    "defaultJurisdiction": "الولاية الافتراضية",
+    "copy": "نسخ",
+    "copied": "تم نسخ العنوان إلى الحافظة",
+    "copyFailed": "فشل نسخ العنوان",
+    "blacklistTitle": "العناوين المحظورة",
+    "clawbacksTitle": "سجلات تدقيق الاسترداد",
+    "noBlacklist": "لا توجد عناوين محظورة",
+    "noClawbacks": "لا توجد سجلات استرداد بعد",
+    "bannedStatus": "محظور",
+    "allowedStatus": "مسموح",
+    "colAddress": "العنوان",
+    "colStatus": "الحالة",
+    "colReason": "السبب",
+    "colUpdated": "آخر تحديث",
+    "colSource": "عنوان المصدر",
+    "colAmount": "المبلغ",
+    "colJurisdiction": "الولاية",
+    "colDate": "التاريخ",
+    "metrics": {
+      "blacklisted": "محظورون",
+      "clawbacks": "عمليات الاسترداد",
+      "events": "أحداث الامتثال",
+      "jurisdiction": "الولاية"
     }
   }
 }

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -100,6 +100,7 @@
       "rejected": "Rejected",
       "signers": "Signers"
     }
+  },
   "nav": {
     "dashboard": "Dashboard",
     "governance": "Governance",
@@ -178,6 +179,43 @@
       "successful": "Successful",
       "failed": "Failed",
       "rate": "Success Rate"
+    }
+  },
+  "compliance": {
+    "pageTitle": "Compliance",
+    "pageSubtitle": "Blacklist management and clawback audit records for token compliance",
+    "badge": "Blacklist & Clawback",
+    "refreshButton": "Refresh",
+    "demoMode": "Running in demo mode — using mock data",
+    "demoHint": "Running in demo mode — backend API not connected. Showing mock data.",
+    "fetchError": "Failed to load compliance data",
+    "configTitle": "Contract Configuration",
+    "admin": "Admin",
+    "clawbackAdmin": "Clawback Admin",
+    "tokenAddress": "Token Contract",
+    "defaultJurisdiction": "Default Jurisdiction",
+    "copy": "Copy",
+    "copied": "Address copied to clipboard",
+    "copyFailed": "Failed to copy address",
+    "blacklistTitle": "Blacklisted Addresses",
+    "clawbacksTitle": "Clawback Audit Records",
+    "noBlacklist": "No blacklisted addresses",
+    "noClawbacks": "No clawback records yet",
+    "bannedStatus": "Banned",
+    "allowedStatus": "Allowed",
+    "colAddress": "Address",
+    "colStatus": "Status",
+    "colReason": "Reason",
+    "colUpdated": "Updated",
+    "colSource": "Source Address",
+    "colAmount": "Amount",
+    "colJurisdiction": "Jurisdiction",
+    "colDate": "Date",
+    "metrics": {
+      "blacklisted": "Blacklisted",
+      "clawbacks": "Clawbacks",
+      "events": "Compliance Events",
+      "jurisdiction": "Jurisdiction"
     }
   }
 }

--- a/client/src/pages/Compliance/Compliance.jsx
+++ b/client/src/pages/Compliance/Compliance.jsx
@@ -1,0 +1,621 @@
+/**
+ * @title Compliance Dashboard
+ * @notice Full-featured dashboard for monitoring and operating the SoroMint
+ *         Compliance contract — blacklist entries, clawback audit records,
+ *         and contract configuration.
+ *
+ * The Compliance contract (docs/compliance.md) lets administrators manage a
+ * blacklist of addresses that are prohibited from interacting with token
+ * functions, and clawback admins can burn tokens from an address while writing
+ * an on-chain audit record.
+ *
+ * Layout (responsive):
+ *   ┌────────────────────────────────────────────────────┐
+ *   │  Page header + Compliance badge + refresh           │
+ *   ├────────────┬────────────┬────────────┬──────────────┤
+ *   │  Blacklist │  Clawback  │  Events    │ Jurisdiction │
+ *   ├────────────┴────────────┴────────────┴──────────────┤
+ *   │  Contract configuration (admin / clawback admin /   │
+ *   │  token / default jurisdiction)                      │
+ *   ├─────────────────────────────────────────────────────┤
+ *   │  Blacklisted addresses table                        │
+ *   ├─────────────────────────────────────────────────────┤
+ *   │  Clawback audit records table                       │
+ *   └─────────────────────────────────────────────────────┘
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+import {
+  ShieldCheck,
+  RefreshCw,
+  Ban,
+  Scale,
+  Activity,
+  Globe,
+  AlertTriangle,
+  UserX,
+  Wallet,
+  Search,
+  Copy,
+} from 'lucide-react';
+
+import SEO from '../../components/SEO';
+import {
+  getComplianceStatus,
+  getBlacklist,
+  getClawbacks,
+  formatBlacklistEntry,
+  formatClawbackRecord,
+} from '../../services/complianceService';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_CONTRACT_ID = 'CCOMPL000000000000000000000000000000000LIANCE';
+
+// ─── Demo data used when backend endpoints are not deployed ──────────────────
+
+const DEMO_STATUS = {
+  blacklistCount: 3,
+  clawbackCount: 2,
+  eventCount: 27,
+  jurisdiction: 'US',
+  admin: 'GADMINXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXMIN',
+  clawbackAdmin: 'GCLAWBACKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXBACK',
+  tokenAddress: 'CSMTTOKENXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXKEN',
+  contractVersion: 'v1.1.0',
+};
+
+const DEMO_BLACKLIST = [
+  {
+    address: 'GBADD01XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX01',
+    banned: true,
+    reason: 'Sanctions match',
+    updatedAt: '2026-08-20T09:15:00Z',
+  },
+  {
+    address: 'GBADD02XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX02',
+    banned: true,
+    reason: 'AML suspicious activity',
+    updatedAt: '2026-08-18T14:30:00Z',
+  },
+  {
+    address: 'GBADD03XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX03',
+    banned: true,
+    reason: 'Court order',
+    updatedAt: '2026-08-10T11:00:00Z',
+  },
+];
+
+const DEMO_CLAWBACKS = [
+  {
+    id: 2,
+    source: 'GBADD01XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX01',
+    amount: 5000,
+    reason: 'fraud',
+    jurisdiction: 'US',
+    timestamp: '2026-08-21T10:05:00Z',
+  },
+  {
+    id: 1,
+    source: 'GBADD02XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX02',
+    amount: 1200,
+    reason: 'sanctions',
+    jurisdiction: 'US',
+    timestamp: '2026-08-19T16:45:00Z',
+  },
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * @notice Truncate a Stellar G/C-address to "GBAB…WXYZ" form.
+ */
+const truncateId = (id) => {
+  if (!id || id === '—') return '—';
+  if (id.length <= 16) return id;
+  return `${id.slice(0, 8)}…${id.slice(-6)}`;
+};
+
+/**
+ * @notice Format a date string to a locale-friendly display.
+ */
+const formatDate = (isoString) => {
+  if (!isoString || isoString === '—') return '—';
+  try {
+    const d = new Date(isoString);
+    return d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '—';
+  }
+};
+
+/**
+ * @notice Copy text to clipboard with a toast confirmation.
+ */
+const copyToClipboard = async (text, t) => {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(t('compliance.copied') || 'Address copied to clipboard');
+  } catch {
+    toast.error(t('compliance.copyFailed') || 'Failed to copy address');
+  }
+};
+
+// ─── Sub-component: Compliance badge ─────────────────────────────────────────
+
+function ComplianceBadge() {
+  const { t } = useTranslation();
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700 dark:border-emerald-700/40 dark:bg-emerald-900/30 dark:text-emerald-400"
+      data-testid="compliance-badge"
+    >
+      <ShieldCheck size={14} />
+      {t('compliance.badge') || 'Blacklist & Clawback'}
+    </span>
+  );
+}
+
+// ─── Sub-component: Metric card ──────────────────────────────────────────────
+
+function MetricCard({ label, value, icon: Icon, color, isLoading }) {
+  return (
+    <div
+      className="glass-card flex flex-col gap-3 !p-5"
+      aria-label={`${label}: ${value}`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-500 dark:text-slate-400">{label}</span>
+        <div
+          className={`flex h-8 w-8 items-center justify-center rounded-xl ${color}`}
+        >
+          <Icon size={16} className="text-white" />
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="h-7 w-20 animate-pulse rounded-lg bg-black/8 dark:bg-white/10" />
+      ) : (
+        <p className="text-2xl font-bold tabular-nums text-slate-900 dark:text-white">
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Sub-component: Config row ───────────────────────────────────────────────
+
+function ConfigRow({ label, value, isMono, testId }) {
+  const { t } = useTranslation();
+  if (!value || value === '—') return null;
+  return (
+    <div className="flex items-center justify-between gap-3 py-2" data-testid={testId}>
+      <span className="text-sm text-slate-500 dark:text-slate-400">{label}</span>
+      <span className="flex items-center gap-2">
+        <span
+          className={`max-w-[220px] truncate text-sm font-medium text-slate-900 dark:text-white ${
+            isMono ? 'font-mono text-stellar-blue' : ''
+          }`}
+        >
+          {isMono ? truncateId(value) : value}
+        </span>
+        {isMono && (
+          <button
+            type="button"
+            onClick={() => copyToClipboard(value, t)}
+            className="text-slate-400 transition hover:text-slate-600 dark:hover:text-slate-200"
+            aria-label={`${t('compliance.copy') || 'Copy'} ${label}`}
+            data-testid={`copy-${testId}`}
+          >
+            <Copy size={14} />
+          </button>
+        )}
+      </span>
+    </div>
+  );
+}
+
+// ─── Sub-component: Contract config card ─────────────────────────────────────
+
+function ConfigCard({ status }) {
+  const { t } = useTranslation();
+  return (
+    <div className="glass-card !p-5" data-testid="config-card">
+      <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-white">
+        <Wallet size={18} className="text-stellar-blue" />
+        {t('compliance.configTitle') || 'Contract Configuration'}
+      </h2>
+      <div className="divide-y divide-black/5 dark:divide-white/5">
+        <ConfigRow
+          label={t('compliance.admin') || 'Admin'}
+          value={status?.admin}
+          isMono
+          testId="config-admin"
+        />
+        <ConfigRow
+          label={t('compliance.clawbackAdmin') || 'Clawback Admin'}
+          value={status?.clawbackAdmin}
+          isMono
+          testId="config-clawback-admin"
+        />
+        <ConfigRow
+          label={t('compliance.tokenAddress') || 'Token Contract'}
+          value={status?.tokenAddress}
+          isMono
+          testId="config-token"
+        />
+        <ConfigRow
+          label={t('compliance.defaultJurisdiction') || 'Default Jurisdiction'}
+          value={status?.jurisdiction}
+          testId="config-jurisdiction"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-component: Blacklist table ──────────────────────────────────────────
+
+function BlacklistTable({ entries, isLoading }) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="glass-card" data-testid="blacklist-loading">
+        <div className="space-y-4 !p-5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex gap-4">
+              <div className="h-5 w-48 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+              <div className="h-5 w-28 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+              <div className="h-5 w-40 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!entries || entries.length === 0) {
+    return (
+      <div
+        className="glass-card flex min-h-[200px] flex-col items-center justify-center !p-5"
+        data-testid="blacklist-empty"
+      >
+        <Search size={40} className="mb-3 text-slate-300 dark:text-slate-600" />
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {t('compliance.noBlacklist') || 'No blacklisted addresses'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card !p-0 overflow-hidden" data-testid="blacklist-table">
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b border-black/5 dark:border-white/10 text-sm text-slate-500 dark:text-slate-400">
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colAddress') || 'Address'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colStatus') || 'Status'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colReason') || 'Reason'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colUpdated') || 'Updated'}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-black/5 dark:divide-white/5">
+            {entries.map((entry, idx) => (
+              <tr
+                key={entry.id || entry.address || idx}
+                className="group transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+                data-testid={`blacklist-row-${idx}`}
+              >
+                <td className="px-5 py-3 font-mono text-sm text-stellar-blue">
+                  {truncateId(entry.address)}
+                </td>
+                <td className="px-5 py-3">
+                  <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400">
+                    <UserX size={12} />
+                    {entry.banned
+                      ? t('compliance.bannedStatus') || 'Banned'
+                      : t('compliance.allowedStatus') || 'Allowed'}
+                  </span>
+                </td>
+                <td className="max-w-[220px] truncate px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
+                  {entry.reason || '—'}
+                </td>
+                <td className="whitespace-nowrap px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
+                  {formatDate(entry.updatedAt)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-component: Clawback table ───────────────────────────────────────────
+
+function ClawbackTable({ records, isLoading }) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="glass-card" data-testid="clawbacks-loading">
+        <div className="space-y-4 !p-5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex gap-4">
+              <div className="h-5 w-16 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+              <div className="h-5 w-48 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+              <div className="h-5 w-24 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+              <div className="h-5 w-28 animate-pulse rounded bg-black/8 dark:bg-white/10" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!records || records.length === 0) {
+    return (
+      <div
+        className="glass-card flex min-h-[200px] flex-col items-center justify-center !p-5"
+        data-testid="clawbacks-empty"
+      >
+        <Scale size={40} className="mb-3 text-slate-300 dark:text-slate-600" />
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {t('compliance.noClawbacks') || 'No clawback records yet'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card !p-0 overflow-hidden" data-testid="clawbacks-table">
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b border-black/5 dark:border-white/10 text-sm text-slate-500 dark:text-slate-400">
+              <th className="px-5 pb-3 pt-4 font-medium">#</th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colSource') || 'Source Address'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colAmount') || 'Amount'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colReason') || 'Reason'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colJurisdiction') || 'Jurisdiction'}
+              </th>
+              <th className="px-5 pb-3 pt-4 font-medium">
+                {t('compliance.colDate') || 'Date'}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-black/5 dark:divide-white/5">
+            {records.map((record, idx) => (
+              <tr
+                key={record.id || record.source || idx}
+                className="group transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+                data-testid={`clawback-row-${idx}`}
+              >
+                <td className="px-5 py-3 text-sm font-medium text-slate-500 dark:text-slate-400">
+                  {record.id ?? idx + 1}
+                </td>
+                <td className="px-5 py-3 font-mono text-sm text-stellar-blue">
+                  {truncateId(record.source)}
+                </td>
+                <td className="px-5 py-3 font-semibold tabular-nums text-slate-900 dark:text-white">
+                  {record.amount != null ? Number(record.amount).toLocaleString() : '—'}
+                </td>
+                <td className="max-w-[180px] truncate px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
+                  {record.reason || '—'}
+                </td>
+                <td className="px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
+                  {record.jurisdiction || '—'}
+                </td>
+                <td className="whitespace-nowrap px-5 py-3 text-sm text-slate-500 dark:text-slate-400">
+                  {formatDate(record.timestamp)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Compliance Dashboard Component ─────────────────────────────────────
+
+function ComplianceDashboard() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState(null);
+  const [blacklist, setBlacklist] = useState([]);
+  const [clawbacks, setClawbacks] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isDemo, setIsDemo] = useState(false);
+
+  // ─── Data fetching ─────────────────────────────────────────────────────────
+
+  const fetchAll = useCallback(
+    async (showToast = false) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const [statusData, blacklistData, clawbackData] = await Promise.all([
+          getComplianceStatus(null, DEMO_STATUS),
+          getBlacklist(null, DEMO_BLACKLIST),
+          getClawbacks(null, DEMO_CLAWBACKS),
+        ]);
+
+        setStatus(statusData);
+        setBlacklist(blacklistData.map(formatBlacklistEntry));
+        setClawbacks(clawbackData.map(formatClawbackRecord));
+
+        // Demo detection: fallback data is returned when backend is not deployed
+        const usedDemo =
+          statusData === DEMO_STATUS ||
+          blacklistData === DEMO_BLACKLIST ||
+          clawbackData === DEMO_CLAWBACKS;
+        setIsDemo(usedDemo);
+        if (usedDemo && showToast) {
+          toast.info(t('compliance.demoMode') || 'Running in demo mode — using mock data');
+        }
+      } catch (err) {
+        setError(err.message);
+        if (showToast) {
+          toast.error(
+            `${t('compliance.fetchError') || 'Failed to load compliance data'}: ${err.message}`
+          );
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [t]
+  );
+
+  useEffect(() => {
+    fetchAll(true);
+  }, [fetchAll]);
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <>
+      <SEO title={t('compliance.pageTitle') || 'Compliance'} />
+
+      {/* Page header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+              {t('compliance.pageTitle') || 'Compliance'}
+            </h1>
+            <ComplianceBadge />
+          </div>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {t('compliance.pageSubtitle') ||
+              'Blacklist management and clawback audit records for token compliance'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => fetchAll(true)}
+          disabled={isLoading}
+          className="inline-flex items-center gap-2 rounded-xl border border-black/10 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:opacity-50 dark:border-white/10 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+          data-testid="refresh-btn"
+        >
+          <RefreshCw size={16} className={isLoading ? 'animate-spin' : ''} />
+          {t('compliance.refreshButton') || 'Refresh'}
+        </button>
+      </div>
+
+      {/* Demo mode hint */}
+      {isDemo && (
+        <div
+          className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800/30 dark:bg-amber-900/20 dark:text-amber-400"
+          data-testid="demo-hint"
+          role="status"
+        >
+          <span className="flex items-center gap-2">
+            <AlertTriangle size={16} />
+            {t('compliance.demoHint') ||
+              'Running in demo mode — backend API not connected. Showing mock data.'}
+          </span>
+        </div>
+      )}
+
+      {/* Error banner */}
+      {error && (
+        <div
+          className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/30 dark:bg-red-900/20 dark:text-red-400"
+          role="alert"
+          data-testid="error-banner"
+        >
+          <span className="flex items-center gap-2">
+            <AlertTriangle size={16} />
+            {error}
+          </span>
+        </div>
+      )}
+
+      {/* Metrics cards */}
+      <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <MetricCard
+          label={t('compliance.metrics.blacklisted') || 'Blacklisted'}
+          value={isLoading ? '—' : (status?.blacklistCount ?? blacklist.length).toLocaleString()}
+          icon={Ban}
+          color="bg-red-500"
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label={t('compliance.metrics.clawbacks') || 'Clawbacks'}
+          value={isLoading ? '—' : (status?.clawbackCount ?? clawbacks.length).toLocaleString()}
+          icon={Scale}
+          color="bg-stellar-blue"
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label={t('compliance.metrics.events') || 'Compliance Events'}
+          value={isLoading ? '—' : (status?.eventCount ?? 0).toLocaleString()}
+          icon={Activity}
+          color="bg-violet-500"
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label={t('compliance.metrics.jurisdiction') || 'Jurisdiction'}
+          value={isLoading ? '—' : status?.jurisdiction || '—'}
+          icon={Globe}
+          color="bg-amber-500"
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Contract configuration */}
+      <div className="mb-6">
+        <ConfigCard status={status} />
+      </div>
+
+      {/* Blacklist table */}
+      <div className="mb-6">
+        <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-white">
+          <Ban size={18} className="text-red-500" />
+          {t('compliance.blacklistTitle') || 'Blacklisted Addresses'}
+        </h2>
+        <BlacklistTable entries={blacklist} isLoading={isLoading} />
+      </div>
+
+      {/* Clawback records table */}
+      <div>
+        <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-white">
+          <Scale size={18} className="text-stellar-blue" />
+          {t('compliance.clawbacksTitle') || 'Clawback Audit Records'}
+        </h2>
+        <ClawbackTable records={clawbacks} isLoading={isLoading} />
+      </div>
+    </>
+  );
+}
+
+export default ComplianceDashboard;

--- a/client/src/pages/Compliance/Compliance.test.jsx
+++ b/client/src/pages/Compliance/Compliance.test.jsx
@@ -1,0 +1,308 @@
+/**
+ * @file Compliance.test.jsx
+ * @description Unit tests for the Compliance dashboard page.
+ *
+ * Coverage:
+ *   1. Page structure — header, badge, metrics, config card
+ *   2. Blacklist table — rows render with status + reason
+ *   3. Clawback table — records render with amount + jurisdiction
+ *   4. Demo-mode hint — shown when fallback data is used
+ *   5. Error handling — API failure shows banner + toast
+ *   6. Refresh button — triggers reload
+ *   7. Accessibility — ARIA labels
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+const mockStatus = {
+  blacklistCount: 3,
+  clawbackCount: 2,
+  eventCount: 27,
+  jurisdiction: 'US',
+  admin: 'GADMINXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXMIN',
+  clawbackAdmin: 'GCLAWBACKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXBACK',
+  tokenAddress: 'CSMTTOKENXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXKEN',
+};
+
+const mockBlacklist = [
+  {
+    address: 'GBADD01XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX01',
+    banned: true,
+    reason: 'Sanctions match',
+    updatedAt: '2026-08-20T09:15:00Z',
+  },
+  {
+    address: 'GBADD02XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX02',
+    banned: true,
+    reason: 'AML suspicious activity',
+    updatedAt: '2026-08-18T14:30:00Z',
+  },
+];
+
+const mockClawbacks = [
+  {
+    id: 2,
+    source: 'GBADD01XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX01',
+    amount: 5000,
+    reason: 'fraud',
+    jurisdiction: 'US',
+    timestamp: '2026-08-21T10:05:00Z',
+  },
+  {
+    id: 1,
+    source: 'GBADD02XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX02',
+    amount: 1200,
+    reason: 'sanctions',
+    jurisdiction: 'US',
+    timestamp: '2026-08-19T16:45:00Z',
+  },
+];
+
+vi.mock('../../services/complianceService', () => ({
+  getComplianceStatus: vi.fn(),
+  getBlacklist: vi.fn(),
+  getClawbacks: vi.fn(),
+  formatBlacklistEntry: vi.fn((entry) => ({
+    id: entry.address,
+    address: entry.address,
+    banned: entry.banned,
+    reason: entry.reason,
+    updatedAt: entry.updatedAt,
+  })),
+  formatClawbackRecord: vi.fn((record) => ({
+    id: record.id,
+    source: record.source,
+    amount: record.amount,
+    reason: record.reason,
+    jurisdiction: record.jurisdiction,
+    timestamp: record.timestamp,
+  })),
+}));
+
+// react-toastify — capture calls without rendering the container
+vi.mock('react-toastify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// react-helmet-async — no-op wrapper
+vi.mock('react-helmet-async', () => ({
+  Helmet: () => null,
+}));
+
+// react-i18next — pass through the key so tests can assert on copy
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key || '',
+  }),
+}));
+
+import ComplianceDashboard from './Compliance';
+import {
+  getComplianceStatus,
+  getBlacklist,
+  getClawbacks,
+} from '../../services/complianceService';
+
+describe('ComplianceDashboard — page structure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getComplianceStatus.mockResolvedValue({ ...mockStatus });
+    getBlacklist.mockResolvedValue(mockBlacklist.map((b) => ({ ...b })));
+    getClawbacks.mockResolvedValue(mockClawbacks.map((c) => ({ ...c })));
+  });
+
+  it('renders the page title and subtitle', async () => {
+    render(<ComplianceDashboard />);
+
+    expect(screen.getByText('compliance.pageTitle')).toBeInTheDocument();
+    expect(screen.getByText('compliance.pageSubtitle')).toBeInTheDocument();
+  });
+
+  it('renders the compliance badge', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compliance-badge')).toBeInTheDocument();
+    });
+  });
+
+  it('renders all four metric cards', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/compliance.metrics.blacklisted/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/compliance.metrics.clawbacks/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/compliance.metrics.events/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/compliance.metrics.jurisdiction/)).toBeInTheDocument();
+    });
+
+    // Metric values from demo/status data
+    expect(screen.getAllByText('3').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('27').length).toBeGreaterThan(0);
+  });
+
+  it('renders the contract configuration card', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('config-card')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('config-admin')).toBeInTheDocument();
+    expect(screen.getByTestId('config-clawback-admin')).toBeInTheDocument();
+    expect(screen.getByTestId('config-token')).toBeInTheDocument();
+    expect(screen.getByTestId('config-jurisdiction')).toBeInTheDocument();
+  });
+});
+
+describe('ComplianceDashboard — blacklist table', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getComplianceStatus.mockResolvedValue({ ...mockStatus });
+    getBlacklist.mockResolvedValue(mockBlacklist.map((b) => ({ ...b })));
+    getClawbacks.mockResolvedValue(mockClawbacks.map((c) => ({ ...c })));
+  });
+
+  it('renders the blacklist table with rows after loading', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('blacklist-table')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('blacklist-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('blacklist-row-1')).toBeInTheDocument();
+  });
+
+  it('renders banned status for blacklist entries', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('blacklist-table')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('compliance.bannedStatus').length).toBeGreaterThan(0);
+    expect(screen.getByText('Sanctions match')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no blacklist entries', async () => {
+    getBlacklist.mockResolvedValue([]);
+
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('blacklist-empty')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ComplianceDashboard — clawback records', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getComplianceStatus.mockResolvedValue({ ...mockStatus });
+    getBlacklist.mockResolvedValue(mockBlacklist.map((b) => ({ ...b })));
+    getClawbacks.mockResolvedValue(mockClawbacks.map((c) => ({ ...c })));
+  });
+
+  it('renders the clawback table with records', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('clawbacks-table')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('clawback-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('clawback-row-1')).toBeInTheDocument();
+    expect(screen.getByText('fraud')).toBeInTheDocument();
+    expect(screen.getByText('sanctions')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no clawback records', async () => {
+    getClawbacks.mockResolvedValue([]);
+
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('clawbacks-empty')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ComplianceDashboard — loading & demo mode', () => {
+  it('shows skeleton loading while fetching', () => {
+    getComplianceStatus.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(mockStatus), 200)),
+    );
+    getBlacklist.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(mockBlacklist), 200)),
+    );
+    getClawbacks.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(mockClawbacks), 200)),
+    );
+
+    render(<ComplianceDashboard />);
+
+    expect(screen.getByTestId('blacklist-loading')).toBeInTheDocument();
+  });
+
+  it('shows demo-mode hint when fallback data was used', async () => {
+    // Simulate the real service behaviour on a downed backend: it returns the
+    // fallback argument (same reference the component passed) — the component
+    // detects demo mode via reference equality with its own DEMO_* constants.
+    getComplianceStatus.mockImplementation((token, fallback) => Promise.resolve(fallback));
+    getBlacklist.mockImplementation((token, fallback) => Promise.resolve(fallback));
+    getClawbacks.mockImplementation((token, fallback) => Promise.resolve(fallback));
+
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('demo-hint')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ComplianceDashboard — error handling', () => {
+  it('shows an error banner and toast when the service fails', async () => {
+    getComplianceStatus.mockRejectedValue(new Error('API unreachable'));
+
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-banner')).toBeInTheDocument();
+    });
+    expect(screen.getByText('API unreachable')).toBeInTheDocument();
+  });
+});
+
+describe('ComplianceDashboard — refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getComplianceStatus.mockResolvedValue({ ...mockStatus });
+    getBlacklist.mockResolvedValue(mockBlacklist.map((b) => ({ ...b })));
+    getClawbacks.mockResolvedValue(mockClawbacks.map((c) => ({ ...c })));
+  });
+
+  it('re-fetches data when refresh is clicked', async () => {
+    render(<ComplianceDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refresh-btn')).toBeInTheDocument();
+    });
+
+    const callsBefore = getComplianceStatus.mock.calls.length;
+    fireEvent.click(screen.getByTestId('refresh-btn'));
+
+    await waitFor(() => {
+      expect(getComplianceStatus.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+});

--- a/client/src/services/complianceService.js
+++ b/client/src/services/complianceService.js
@@ -1,0 +1,147 @@
+/**
+ * @title Compliance API Service
+ * @notice Client-side service for fetching and interacting with the SoroMint
+ *         Compliance contract state — blacklist entries, clawback audit
+ *         records, and contract configuration.
+ *
+ * API endpoints (built on the generic event indexer from docs/architecture/compliance.md):
+ *   GET  /api/compliance/status        — blacklist count, clawback count, config
+ *   GET  /api/compliance/blacklist     — list of blacklisted addresses
+ *   GET  /api/compliance/clawbacks     — list of clawback audit records
+ *
+ * The Compliance contract emits `bl_upd`, `clwbk`, `cfg_upd`, `token_set`,
+ * and `cb_admin` events which the backend indexes into MongoDB (SorobanEvent
+ * collection) and serves through the endpoints above.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @notice Thin fetch wrapper — throws an Error with the API error message on
+ *         non-2xx responses.
+ */
+const apiFetch = async (path, opts = {}, token = null) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(opts.headers || {}),
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, { ...opts, headers });
+
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    throw new Error(`Server returned a non-JSON response (HTTP ${res.status})`);
+  }
+
+  if (!res.ok) {
+    const message =
+      body?.error || body?.message || `Request failed with status ${res.status}`;
+    const err = new Error(message);
+    err.status = res.status;
+    err.code = body?.code;
+    throw err;
+  }
+
+  return body;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @notice Fetch compliance snapshot (blacklist + clawback + config summary).
+ *
+ * @param {string}  [token]    — Optional JWT auth token
+ * @param {object}  [fallback] — Optional mock data used when the backend
+ *                               endpoint is not deployed (demo mode)
+ * @returns {Promise<object>} Compliance status object
+ */
+export const getComplianceStatus = async (token = null, fallback = null) => {
+  try {
+    const body = await apiFetch('/compliance/status', {}, token);
+    return body?.data || body;
+  } catch (err) {
+    if (fallback && (err.status === 404 || err.status === 501 || err.status === 502)) {
+      return fallback;
+    }
+    throw err;
+  }
+};
+
+/**
+ * @notice Fetch the list of blacklisted addresses.
+ *
+ * @param {string}  [token]    — Optional JWT auth token
+ * @param {Array}   [fallback] — Optional mock data used in demo mode
+ * @returns {Promise<Array<object>>} Blacklist entries
+ */
+export const getBlacklist = async (token = null, fallback = null) => {
+  try {
+    const body = await apiFetch('/compliance/blacklist', {}, token);
+    return Array.isArray(body) ? body : body?.data || body?.entries || [];
+  } catch (err) {
+    if (fallback && (err.status === 404 || err.status === 501 || err.status === 502)) {
+      return fallback;
+    }
+    throw err;
+  }
+};
+
+/**
+ * @notice Fetch clawback audit records.
+ *
+ * @param {string}  [token]    — Optional JWT auth token
+ * @param {Array}   [fallback] — Optional mock data used in demo mode
+ * @returns {Promise<Array<object>>} Clawback records
+ */
+export const getClawbacks = async (token = null, fallback = null) => {
+  try {
+    const body = await apiFetch('/compliance/clawbacks', {}, token);
+    return Array.isArray(body) ? body : body?.data || body?.records || [];
+  } catch (err) {
+    if (fallback && (err.status === 404 || err.status === 501 || err.status === 502)) {
+      return fallback;
+    }
+    throw err;
+  }
+};
+
+/**
+ * @notice Format a blacklist entry for display.
+ *
+ * @param {object} entry — { address, banned, reason?, updatedAt }
+ * @returns {object} Formatted entry
+ */
+export const formatBlacklistEntry = (entry = {}) => ({
+  id: entry._id || entry.id || entry.address || '',
+  address: entry.address || entry.addr || '—',
+  banned: entry.banned ?? entry.status === 'banned',
+  reason: entry.reason || '—',
+  updatedAt: entry.updatedAt || entry.createdAt || '—',
+});
+
+/**
+ * @notice Format a clawback record for display.
+ *
+ * @param {object} record — ClawbackRecord shape from the Compliance contract
+ * @returns {object} Formatted record
+ */
+export const formatClawbackRecord = (record = {}) => ({
+  id: record.id ?? record.recordId ?? record._id ?? '',
+  source: record.source || record.from || '—',
+  amount: record.amount ?? 0,
+  reason: record.reason || '—',
+  jurisdiction: record.jurisdiction || '—',
+  timestamp: record.timestamp || record.ledgerTimestamp || record.createdAt || '—',
+});


### PR DESCRIPTION
## Summary

Implements **#733 — Design and implement Dashboard UI for Compliance**.

Adds a full Compliance dashboard to the SoroMint client, following the established pattern of the already-merged Multisig (#800), Backstop (#798), and ZK Audit Log (#799) dashboards.

## Changes

### New files

- **`client/src/pages/Compliance/Compliance.jsx`** — Compliance dashboard with:
  - 4 metric cards: blacklisted addresses, clawback records, compliance events, default jurisdiction
  - Contract configuration card (admin, clawback admin, token contract, jurisdiction) with copy-to-clipboard
  - Blacklisted addresses table (address, status badge, reason, updated date)
  - Clawback audit records table (id, source address, amount, reason, jurisdiction, date)
  - Demo-mode hint + error banner + loading skeletons, matching the existing dashboard pattern
  - Fully responsive TailwindCSS layout with dark-mode support
- **`client/src/pages/Compliance/Compliance.test.jsx`** — 13 unit tests (RTL): page structure, metrics, config card, blacklist/clawback tables, empty states, demo mode, error handling, refresh
- **`client/src/services/complianceService.js`** — service layer with demo-data fallback for when backend endpoints are not deployed

### Modified files

- **`client/src/App.jsx`** — lazy-loaded Compliance view wired into the nav (`id: "compliance"`, Scale icon), with Suspense + ErrorBoundary
- **`client/src/locales/en/translation.json`** & **`client/src/locales/ar/translation.json`** — add `compliance` i18n keys (EN + AR). Also fixes a **pre-existing broken JSON structure** (an unclosed `multisig` block caused a duplicate `nav` key and invalid JSON on `main`).

## Verification

- `npx vitest run src/pages/Compliance/Compliance.test.jsx` → **13/13 passing**
- Component follows the same conventions as the merged Multisig/Backstop/ZKAuditLog dashboards

## Notes

- Data layer mirrors the docs/compliance.md + docs/architecture/compliance.md contract design (blacklist + clawback + events), with demo fallback until backend endpoints are deployed.
